### PR TITLE
Explicitly setting servlet load order in web.xml so that Tomcat behaves the same as Jetty

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -13,7 +13,7 @@
         <param-name>com.sun.jersey.config.property.packages</param-name>
         <param-value>com.netflix.simianarmy.resources</param-value>
       </init-param>
-      <load-on-startup>1</load-on-startup>
+      <load-on-startup>2</load-on-startup>
     </servlet>
     <servlet-mapping>
       <servlet-name>jersey-servlet</servlet-name>


### PR DESCRIPTION
Hello,
It looks like the problem we had with tomcat was related to the load-on-startup parameter used in web.xml.Because it's up to the servlet container (Jetty or Tomcat) which order it loads servlets that have the same <load-on-startup/> value, we noticed the following variation on loading:

Jetty: 1. Monkey Server, 2. jersey-servlet
Tomcat: 1. jersey-servlet , 2. Monkey Server

So we explicitly set a larger number for jersey-servlet to ensure same load order in Tomcat as in Jetty. For details on load order, see snippet from servlet 2.5 specification at the bottom of this post.
### Fixed web.xml

```
<web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee ">
    <servlet>
        <servlet-name>Monkey Server</servlet-name>
        <servlet-class>com.netflix.simianarmy.basic.BasicMonkeyServer</servlet-class>
        <load-on-startup>1</load-on-startup>
    </servlet>
    <servlet>
      <servlet-name>jersey-servlet</servlet-name>
      <servlet-class>com.sun.jersey.spi.container.servlet.ServletContainer</servlet-class>
      <init-param>
        <param-name>com.sun.jersey.config.property.packages</param-name>
        <param-value>com.netflix.simianarmy.resources</param-value>
      </init-param>
      <load-on-startup>2</load-on-startup>
    </servlet>
    <servlet-mapping>
      <servlet-name>jersey-servlet</servlet-name>
      <url-pattern>/api/*</url-pattern>
    </servlet-mapping>
</web-app>
```
### Servlet 2.5 Specification snippet

```
<xsd:element name="load-on-startup"
type="javaee:load-on-startupType"
minOccurs="0">
<xsd:annotation>
<xsd:documentation>
The load-on-startup element indicates that this
servlet should be loaded (instantiated and have
its init() called) on the startup of the web
application. The optional contents of these
element must be an integer indicating the order in
which the servlet should be loaded. If the value
is a negative integer, or the element is not
present, the container is free to load the servlet
whenever it chooses. If the value is a positive
integer or 0, the container must load and
initialize the servlet as the application is
deployed. ***The container must guarantee that
servlets marked with lower integers are loaded
before servlets marked with higher integers. The
container may choose the order of loading of
servlets with the same load-on-start-up value.***
</xsd:documentation>
</xsd:annotation>
```
