### PR TITLE
Update aws-java-sdk to latest version (1.5.3)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     compile 'org.codehaus.jackson:jackson-core-asl:1.9.2'
     compile 'org.codehaus.jackson:jackson-mapper-asl:1.9.2'
     compile 'com.netflix.eureka:eureka-client:1.1.22'
-    compile 'com.amazonaws:aws-java-sdk:1.5.3'
+    compile 'com.amazonaws:aws-java-sdk:latest.release'
     compile 'commons-lang:commons-lang:2.6'
     compile 'joda-time:joda-time:2.0'
     compile 'com.google.guava:guava:11.+'


### PR DESCRIPTION
Noticed that the version of the aws-java-sdk was fairly old, this is an update to latest version.
