### PR TITLE
Add option for running in Cloud Formation mode to default client properties file

### DIFF
--- a/src/main/resources/client.properties
+++ b/src/main/resources/client.properties
@@ -31,3 +31,8 @@ simianarmy.client.aws.region = us-west-1
 #
 #simianarmy.client.vsphere.terminationStrategy.property.name=Force Boot
 #simianarmy.client.vsphere.terminationStrategy.property.value=server
+
+### Operate in Cloud Formation mode - the random suffix appended to Auto Scaling Group names is ignored
+### (specify ASG names as usual with no suffix in chaos.properties)  
+#
+#simianarmy.client.chaos.class=com.netflix.simianarmy.basic.chaos.CloudFormationChaosMonkey


### PR DESCRIPTION
Pull Request #62 introduced the ability to run in a Cloud Formation compatible mode whereby the random string appended to Auto Scaling Group names is ignored for their identification by the Monkeys.

This surfaces the option to enable this with a comment as to its operation.
