### PR TITLE
Don't send an email to foo@bar.com

### DIFF
--- a/src/main/java/com/netflix/simianarmy/aws/AWSEmailNotifier.java
+++ b/src/main/java/com/netflix/simianarmy/aws/AWSEmailNotifier.java
@@ -94,11 +94,14 @@ public abstract class AWSEmailNotifier implements MonkeyEmailNotifier {
         if (email == null) {
             return false;
         }
-        if (emailPattern.matcher(email).matches()) {
-            return true;
-        } else {
+        if (!emailPattern.matcher(email).matches()) {
             LOGGER.error(String.format("Invalid email address: %s", email));
             return false;
         }
+        if (email.equals("foo@bar.com")) {
+            LOGGER.error(String.format("Email address not changed from default; treating as invalid: %s", email));
+            return false;
+        }
+        return true;
     }
 }


### PR DESCRIPTION
If the user hasn't changed the default, don't even try to send an email to foo@bar.com.
