### PR TITLE
Trim boolean configuration before parsing

### DIFF
--- a/src/main/java/com/netflix/simianarmy/basic/BasicConfiguration.java
+++ b/src/main/java/com/netflix/simianarmy/basic/BasicConfiguration.java
@@ -48,7 +48,11 @@ public class BasicConfiguration implements MonkeyConfiguration {
     @Override
     public boolean getBoolOrElse(String property, boolean dflt) {
         String val = props.getProperty(property);
-        return val == null ? dflt : Boolean.parseBoolean(val);
+        if (val == null) {
+            return dflt;
+        }
+        val = val.trim();
+        return Boolean.parseBoolean(val);
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
Boolean.parseBoolean() is strict with respects to whitespace.  When following the install guide, I ended up with whitespace in my configuration.  "True " was parsed as false.

Rather than fix the configuration instructions, it is much easier and more friendly to simply trim the value before parsing it, i.e. be tolerant in what we accept.
