### PR TITLE
Handle empty response content in MonkeyRestClient.

### DIFF
--- a/src/main/java/com/netflix/simianarmy/client/MonkeyRestClient.java
+++ b/src/main/java/com/netflix/simianarmy/client/MonkeyRestClient.java
@@ -59,7 +59,8 @@ public abstract class MonkeyRestClient {
         InputStream is = response.getEntity().getContent();
         String jsonContent;
         if (is != null) {
-            jsonContent = new Scanner(is, "UTF-8").useDelimiter("\\A").next();
+            Scanner s = new Scanner(is, "UTF-8").useDelimiter("\\A");
+            jsonContent = s.hasNext() ? s.next() : "";
             is.close();
         } else {
             return null;


### PR DESCRIPTION
This pull request adds logic to handle empty content responses such as 413.
