### PR TITLE
Fallback instance to ami

### DIFF
--- a/src/main/java/com/netflix/simianarmy/aws/janitor/crawler/edda/EddaInstanceJanitorCrawler.java
+++ b/src/main/java/com/netflix/simianarmy/aws/janitor/crawler/edda/EddaInstanceJanitorCrawler.java
@@ -244,7 +244,7 @@ public class EddaInstanceJanitorCrawler implements JanitorCrawler {
                 imageJsonNode = eddaClient.getJsonNodeFromUrl(url);
             } catch (Exception e) {
                 LOGGER.error(String.format(
-                        "Failed to get Jason node from edda for AMIs in region %s.", region), e);
+                        "Failed to get Json node from edda for AMIs in region %s.", region), e);
             }
             if (imageJsonNode == null) {
                 return;


### PR DESCRIPTION
Edda instance crawler use AMI's owner tag as instance owner if instance does not have owner.
