### PR TITLE
fix test failure when daylight saving time to normal time

### DIFF
--- a/src/test/java/com/netflix/simianarmy/aws/janitor/rule/instance/TestOrphanedInstanceRule.java
+++ b/src/test/java/com/netflix/simianarmy/aws/janitor/rule/instance/TestOrphanedInstanceRule.java
@@ -175,6 +175,6 @@ public class TestOrphanedInstanceRule {
     private void verifyTerminationTime(Resource resource, int retentionDays, DateTime now) {
         int hours = (int) (resource.getExpectedTerminationTime().getTime() - now.getMillis()) / (60 * 60 * 1000);
         // There could be a 1-hour difference if the time passes the daylight saving time change
-        Assert.assertTrue(hours >= retentionDays * 24 - 1 && hours <= retentionDays * 24);
+        Assert.assertTrue(hours >= retentionDays * 24 - 1 && hours <= retentionDays * 24 + 1);
     }
 }


### PR DESCRIPTION
Original test only works when time switch from normal time to daylight saving time.
