### PR TITLE
Abstraction of email transport and message generation.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,11 +51,13 @@ dependencies {
     compile 'com.google.guava:guava:11.+'
     compile 'org.apache.httpcomponents:httpclient:4.2.1'
     compile 'org.apache.httpcomponents:httpcore:4.2.1'
+    compile 'org.apache.commons:commons-email:1.3.2'
     compile 'org.jclouds.driver:jclouds-jsch:1.6.0'
     compile 'org.jclouds.driver:jclouds-slf4j:1.6.0'
 
     testCompile 'org.testng:testng:6.3.1'
     testCompile 'org.mockito:mockito-core:1.8.5'
+    testCompile 'org.subethamail:subethasmtp:3.1.7'
 
     runtime 'org.slf4j:slf4j-log4j12:1.6.1'
 

--- a/gradle/convention.gradle
+++ b/gradle/convention.gradle
@@ -1,7 +1,5 @@
 apply plugin: 'java' // Plugin as major conventions, overwrites status
 
-sourceCompatibility = 1.6
-
 // GRADLE-2087 workaround, perform after java plugin
 status = project.hasProperty('preferredStatus')?project.preferredStatus:(version.contains('SNAPSHOT')?'snapshot':'release')
 

--- a/src/main/java/com/netflix/simianarmy/EmailClient.java
+++ b/src/main/java/com/netflix/simianarmy/EmailClient.java
@@ -1,0 +1,43 @@
+/*
+ *
+ *  Copyright 2014 Salesforce.com, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.simianarmy;
+
+
+/** 
+ * The interface for the email client used by monkeys. Generally, the EmailClient is used by a Notifier 
+ * to use a mail-specific API to construct and deliver the message.
+ */
+public interface EmailClient {
+
+    /**
+     * Determines if a email address is valid.
+     * @param email the email
+     * @return true if the email address is valid, false otherwise.
+     */
+    boolean isValidEmail(String email);
+
+    /**
+     * Sends an email.
+     * @param to the address sent to
+     * @param from the address of the sender
+     * @param cc addresses to carbon-copy the email to
+     * @param subject the email subject
+     * @param body the email body
+     */
+    void sendEmail(String to, String from, String[] cc, String subject, String body);
+}

--- a/src/main/java/com/netflix/simianarmy/EmailClient.java
+++ b/src/main/java/com/netflix/simianarmy/EmailClient.java
@@ -18,8 +18,8 @@
 package com.netflix.simianarmy;
 
 
-/** 
- * The interface for the email client used by monkeys. Generally, the EmailClient is used by a Notifier 
+/**
+ * The interface for the email client used by monkeys. Generally, the EmailClient is used by a Notifier
  * to use a mail-specific API to construct and deliver the message.
  */
 public interface EmailClient {

--- a/src/main/java/com/netflix/simianarmy/MonkeyEmailNotifier.java
+++ b/src/main/java/com/netflix/simianarmy/MonkeyEmailNotifier.java
@@ -22,13 +22,6 @@ package com.netflix.simianarmy;
 public interface MonkeyEmailNotifier {
 
     /**
-     * Determines if a email address is valid.
-     * @param email the email
-     * @return true if the email address is valid, false otherwise.
-     */
-    boolean isValidEmail(String email);
-
-    /**
      * Builds an email subject for an email address.
      * @param to the destination email address
      * @return the email subject
@@ -48,12 +41,4 @@ public interface MonkeyEmailNotifier {
      * @return the source email addresses
      */
     String getSourceAddress(String to);
-
-    /**
-     * Sends an email.
-     * @param to the address sent to
-     * @param subject the email subject
-     * @param body the email body
-     */
-    void sendEmail(String to, String subject, String body);
 }

--- a/src/main/java/com/netflix/simianarmy/aws/AWSEmailClient.java
+++ b/src/main/java/com/netflix/simianarmy/aws/AWSEmailClient.java
@@ -45,10 +45,10 @@ public class AWSEmailClient extends BasicEmailClient {
      * The constructor.
      */
     public AWSEmailClient() {
-        super();//at this time, AWSEmailClient does not rely on any property configurations
+        super(); //at this time, AWSEmailClient does not rely on any property configurations
         this.sesClient = new AmazonSimpleEmailServiceClient();
     }
-    
+
     /* (non-Javadoc)
      * @see com.netflix.simianarmy.basic.BasicEmailClient#buildAndSendEmail(String, String, String[], String, String)
      */

--- a/src/main/java/com/netflix/simianarmy/aws/AWSEmailClient.java
+++ b/src/main/java/com/netflix/simianarmy/aws/AWSEmailClient.java
@@ -1,0 +1,76 @@
+/*
+ *
+ *  Copyright 2013 Salesforce.com, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.simianarmy.aws;
+
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient;
+import com.amazonaws.services.simpleemail.model.Body;
+import com.amazonaws.services.simpleemail.model.Content;
+import com.amazonaws.services.simpleemail.model.Destination;
+import com.amazonaws.services.simpleemail.model.Message;
+import com.amazonaws.services.simpleemail.model.SendEmailRequest;
+import com.amazonaws.services.simpleemail.model.SendEmailResult;
+import com.netflix.simianarmy.basic.BasicEmailClient;
+
+/**
+ * The class implements the EmailClient interface using AWS simple email service
+ * for sending email.
+ */
+public class AWSEmailClient extends BasicEmailClient {
+    /** The Constant LOGGER. */
+    private static final Logger LOGGER = LoggerFactory.getLogger(AWSEmailClient.class);
+
+    private final AmazonSimpleEmailServiceClient sesClient;
+
+    /**
+     * The constructor.
+     */
+    public AWSEmailClient() {
+        super();//at this time, AWSEmailClient does not rely on any property configurations
+        this.sesClient = new AmazonSimpleEmailServiceClient();
+    }
+    
+    /* (non-Javadoc)
+     * @see com.netflix.simianarmy.basic.BasicEmailClient#buildAndSendEmail(String, String, String[], String, String)
+     */
+    @Override
+    protected String buildAndSendEmail(String to, String from, String[] cc, String subject, String body) {
+        if (sesClient == null) {
+            String msg = "The email client is not set.";
+            LOGGER.error(msg);
+            throw new RuntimeException(msg);
+        }
+        Destination destination = new Destination().withToAddresses(to)
+                .withCcAddresses(cc);
+        Content subjectContent = new Content(subject);
+        Content bodyContent = new Content();
+        Body msgBody = new Body(bodyContent);
+        msgBody.setHtml(new Content(body));
+        Message msg = new Message(subjectContent, msgBody);
+        SendEmailRequest request = new SendEmailRequest(from, destination, msg);
+        request.setReturnPath(from);
+        LOGGER.debug(String.format("Sending email with subject '%s' to %s",
+                subject, to));
+        SendEmailResult result = sesClient.sendEmail(request);
+        return result.getMessageId();
+    }
+}

--- a/src/main/java/com/netflix/simianarmy/aws/AWSEmailNotifier.java
+++ b/src/main/java/com/netflix/simianarmy/aws/AWSEmailNotifier.java
@@ -99,7 +99,7 @@ public abstract class AWSEmailNotifier implements MonkeyEmailNotifier {
 
     /**Indicates whether email is valid for use by simian army.
      * @param email
-     * @return
+     * @return true if email is valid, false if it is not
      */
     public boolean isValidEmail(String email) {
         if (email == null) {

--- a/src/main/java/com/netflix/simianarmy/aws/AWSEmailNotifier.java
+++ b/src/main/java/com/netflix/simianarmy/aws/AWSEmailNotifier.java
@@ -34,7 +34,10 @@ import com.netflix.simianarmy.MonkeyEmailNotifier;
 
 /**
  * The class implements the monkey email notifier using AWS simple email service
- * for sending email.
+ * for sending email.  This class could be deprecated in the future, but 
+ * the Janitor and Conformity monkeys use it directly, and their behavior is 
+ * so AWS-specific that no real use case exists (yet) that requires a refactoring
+ * and abstraction of their functionality. 
  */
 public abstract class AWSEmailNotifier implements MonkeyEmailNotifier {
     /** The Constant LOGGER. */
@@ -56,7 +59,6 @@ public abstract class AWSEmailNotifier implements MonkeyEmailNotifier {
         this.emailPattern = Pattern.compile(EMAIL_PATTERN);
     }
 
-    @Override
     public void sendEmail(String to, String subject, String body) {
         if (!isValidEmail(to)) {
             LOGGER.error(String.format("The destination email address %s is not valid,  no email is sent.", to));
@@ -89,7 +91,6 @@ public abstract class AWSEmailNotifier implements MonkeyEmailNotifier {
                 to, result.getMessageId(), subject));
     }
 
-    @Override
     public boolean isValidEmail(String email) {
         if (email == null) {
             return false;

--- a/src/main/java/com/netflix/simianarmy/aws/AWSEmailNotifier.java
+++ b/src/main/java/com/netflix/simianarmy/aws/AWSEmailNotifier.java
@@ -34,10 +34,10 @@ import com.netflix.simianarmy.MonkeyEmailNotifier;
 
 /**
  * The class implements the monkey email notifier using AWS simple email service
- * for sending email.  This class could be deprecated in the future, but 
- * the Janitor and Conformity monkeys use it directly, and their behavior is 
+ * for sending email.  This class could be deprecated in the future, but
+ * the Janitor and Conformity monkeys use it directly, and their behavior is
  * so AWS-specific that no real use case exists (yet) that requires a refactoring
- * and abstraction of their functionality. 
+ * and abstraction of their functionality.
  */
 public abstract class AWSEmailNotifier implements MonkeyEmailNotifier {
     /** The Constant LOGGER. */
@@ -59,6 +59,12 @@ public abstract class AWSEmailNotifier implements MonkeyEmailNotifier {
         this.emailPattern = Pattern.compile(EMAIL_PATTERN);
     }
 
+    /**
+     * Sends the email notification.
+     * @param to address of recipient
+     * @param subject subject of message
+     * @param body message content
+     */
     public void sendEmail(String to, String subject, String body) {
         if (!isValidEmail(to)) {
             LOGGER.error(String.format("The destination email address %s is not valid,  no email is sent.", to));
@@ -91,6 +97,10 @@ public abstract class AWSEmailNotifier implements MonkeyEmailNotifier {
                 to, result.getMessageId(), subject));
     }
 
+    /**Indicates whether email is valid for use by simian army.
+     * @param email
+     * @return
+     */
     public boolean isValidEmail(String email) {
         if (email == null) {
             return false;

--- a/src/main/java/com/netflix/simianarmy/basic/BasicChaosMonkeyContext.java
+++ b/src/main/java/com/netflix/simianarmy/basic/BasicChaosMonkeyContext.java
@@ -17,7 +17,6 @@
  */
 package com.netflix.simianarmy.basic;
 
-import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient;
 import com.netflix.simianarmy.MonkeyConfiguration;
 import com.netflix.simianarmy.basic.chaos.BasicChaosEmailNotifier;
 import com.netflix.simianarmy.basic.chaos.BasicChaosInstanceSelector;
@@ -28,7 +27,7 @@ import com.netflix.simianarmy.chaos.ChaosMonkey;
 import com.netflix.simianarmy.client.aws.chaos.ASGChaosCrawler;
 
 /**
- * The Class BasicContext. This provide the basic context needed for the Chaos Monkey to run. It will configure
+ * The Class BasicChaosMonkeyContext. This provide the basic context needed for the Chaos Monkey to run. It will configure
  * the Chaos Monkey based on a simianarmy.properties file and chaos.properties. The properties file can be
  * overridden with -Dsimianarmy.properties=/path/to/my.properties
  */
@@ -42,7 +41,7 @@ public class BasicChaosMonkeyContext extends BasicSimianArmyContext implements C
 
     /** The chaos email notifier. */
     private ChaosEmailNotifier chaosEmailNotifier;
-
+    
     /**
      * Instantiates a new basic context.
      */
@@ -51,9 +50,9 @@ public class BasicChaosMonkeyContext extends BasicSimianArmyContext implements C
         setChaosCrawler(new ASGChaosCrawler(awsClient()));
         setChaosInstanceSelector(new BasicChaosInstanceSelector());
         MonkeyConfiguration cfg = configuration();
-        setChaosEmailNotifier(new BasicChaosEmailNotifier(cfg, new AmazonSimpleEmailServiceClient(), null));
+        setChaosEmailNotifier(new BasicChaosEmailNotifier(cfg, null));
     }
-
+    
     /** {@inheritDoc} */
     @Override
     public ChaosCrawler chaosCrawler() {

--- a/src/main/java/com/netflix/simianarmy/basic/BasicChaosMonkeyContext.java
+++ b/src/main/java/com/netflix/simianarmy/basic/BasicChaosMonkeyContext.java
@@ -27,9 +27,9 @@ import com.netflix.simianarmy.chaos.ChaosMonkey;
 import com.netflix.simianarmy.client.aws.chaos.ASGChaosCrawler;
 
 /**
- * The Class BasicChaosMonkeyContext. This provide the basic context needed for the Chaos Monkey to run. It will configure
- * the Chaos Monkey based on a simianarmy.properties file and chaos.properties. The properties file can be
- * overridden with -Dsimianarmy.properties=/path/to/my.properties
+ * The Class BasicChaosMonkeyContext. This provide the basic context needed for the Chaos Monkey to run.
+ * It will configure the Chaos Monkey based on a simianarmy.properties file and chaos.properties.
+ * The properties file can be overridden with -Dsimianarmy.properties=/path/to/my.properties
  */
 public class BasicChaosMonkeyContext extends BasicSimianArmyContext implements ChaosMonkey.Context {
 
@@ -41,7 +41,7 @@ public class BasicChaosMonkeyContext extends BasicSimianArmyContext implements C
 
     /** The chaos email notifier. */
     private ChaosEmailNotifier chaosEmailNotifier;
-    
+
     /**
      * Instantiates a new basic context.
      */
@@ -52,7 +52,7 @@ public class BasicChaosMonkeyContext extends BasicSimianArmyContext implements C
         MonkeyConfiguration cfg = configuration();
         setChaosEmailNotifier(new BasicChaosEmailNotifier(cfg, null));
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public ChaosCrawler chaosCrawler() {

--- a/src/main/java/com/netflix/simianarmy/basic/BasicEmailClient.java
+++ b/src/main/java/com/netflix/simianarmy/basic/BasicEmailClient.java
@@ -9,7 +9,7 @@ import com.netflix.simianarmy.EmailClient;
 import com.netflix.simianarmy.MonkeyConfiguration;
 
 /**
- * This class provides basic functionality for delivering a message by email.
+ * This class provides basic functionality for delivering email.
  * Subclasses will implement the actual transport code, and optionally redefine the rules
  * of what makes an email address valid.
  * @author mgeis
@@ -22,12 +22,12 @@ public abstract class BasicEmailClient implements EmailClient {
                     + "[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$";
 
     private static final Pattern emailPattern;
-    protected final MonkeyConfiguration cfg;
-    
+    private final MonkeyConfiguration cfg;
+
     static {
         emailPattern = Pattern.compile(EMAIL_PATTERN);
     }
-    
+
     /**
      * The constructor.  Some transports requirea config to determine their connection parameters
      * (for example, connecting directly to an SMTP server).
@@ -36,21 +36,22 @@ public abstract class BasicEmailClient implements EmailClient {
     public BasicEmailClient(MonkeyConfiguration cfg) {
         this.cfg = cfg;
     }
-    
+
     /**
      * The constructor.  The no-arg constructor exists because some email transports are assumed
      * to be running in a service-oriented environment in which context is already available (for
-     * example, AWS).  
+     * example, AWS).
      */
     public BasicEmailClient() {
         this(null);
     }
-    
+
     /**
      * Takes email content, initializes the necessary java classes, and delivers the mail.
      * This method takes care of the mail API internals.  The rest of the code that decorates the
      * message delivery (such as logging, exception handling) is in <code>sendEmail</code>.
-     * Exceptions encountered should be either <code>RuntimeException</code> or wrapped in a <code>RuntimeException</code>
+     * Exceptions encountered should be either <code>RuntimeException</code> or wrapped in a
+     * <code>RuntimeException</code>
      * @param to
      * @param from
      * @param cc
@@ -60,18 +61,18 @@ public abstract class BasicEmailClient implements EmailClient {
      * @see #sendEmail(String, String, String[], String, String)
      */
     protected abstract String buildAndSendEmail(String to, String from, String[] cc, String subject, String body);
-    
+
     /**
-     * Checks email validity and raises exception if it does not pass the test
+     * Checks email validity and raises exception if it does not pass the test.
      * @param address
      * @throws IllegalArgumentException if the email address provided is invalid
      */
     public void validateEmail(String address) {
-        if(!isValidEmail(address)) {
+        if (!isValidEmail(address)) {
             throw new IllegalArgumentException(String.format("Invalid email address: %s", address));
         }
     }
-    
+
     /* (non-Javadoc)
      * @see com.netflix.simianarmy.EmailClient#sendEmail(String, String, String[], String, String)
      */
@@ -80,18 +81,18 @@ public abstract class BasicEmailClient implements EmailClient {
         try {
             try {
                 validateEmail(to);
-            } catch(IllegalArgumentException iae) {
+            } catch (IllegalArgumentException iae) {
                 LOGGER.error(String.format("The destination email address %s is not valid,  no email is sent.", to));
                 return;
             }
             String messageId = buildAndSendEmail(to, from, cc, subject, body);
             LOGGER.info(String.format("Email to %s, result id is %s, subject is %s",
                 to, messageId, subject));
-        } catch(Exception e) {
+        } catch (Exception e) {
             throw new RuntimeException(String.format("Failed to send email to %s", to), e);
         }
     }
-    
+
     /* (non-Javadoc)
      * @see com.netflix.simianarmy.EmailClient#isValidEmail(String)
      */
@@ -110,5 +111,9 @@ public abstract class BasicEmailClient implements EmailClient {
         }
         return true;
     }
-    
+
+    public MonkeyConfiguration getCfg() {
+        return cfg;
+    }
+
 }

--- a/src/main/java/com/netflix/simianarmy/basic/BasicEmailClient.java
+++ b/src/main/java/com/netflix/simianarmy/basic/BasicEmailClient.java
@@ -1,0 +1,114 @@
+package com.netflix.simianarmy.basic;
+
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netflix.simianarmy.EmailClient;
+import com.netflix.simianarmy.MonkeyConfiguration;
+
+/**
+ * This class provides basic functionality for delivering a message by email.
+ * Subclasses will implement the actual transport code, and optionally redefine the rules
+ * of what makes an email address valid.
+ * @author mgeis
+ *
+ */
+public abstract class BasicEmailClient implements EmailClient {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BasicEmailClient.class);
+    private static final String EMAIL_PATTERN =
+            "^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@"
+                    + "[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$";
+
+    private static final Pattern emailPattern;
+    protected final MonkeyConfiguration cfg;
+    
+    static {
+        emailPattern = Pattern.compile(EMAIL_PATTERN);;
+    }
+    
+    /**
+     * The constructor.  Some transports requirea config to determine their connection parameters
+     * (for example, connecting directly to an SMTP server).
+     * @param cfg
+     */
+    public BasicEmailClient(MonkeyConfiguration cfg) {
+        this.cfg = cfg;
+    }
+    
+    /**
+     * The constructor.  The no-arg constructor exists because some email transports are assumed
+     * to be running in a service-oriented environment in which context is already available (for
+     * example, AWS).  
+     */
+    public BasicEmailClient() {
+        this(null);
+    }
+    
+    /**
+     * Takes email content, initializes the necessary java classes, and delivers the mail.
+     * This method takes care of the mail API internals.  The rest of the code that decorates the
+     * message delivery (such as logging, exception handling) is in <code>sendEmail</code>.
+     * Exceptions encountered should be either <code>RuntimeException</code> or wrapped in a <code>RuntimeException</code>
+     * @param to
+     * @param from
+     * @param cc
+     * @param subject
+     * @param body
+     * @return The message id of the delivered message
+     * @see #sendEmail(String, String, String[], String, String)
+     */
+    protected abstract String buildAndSendEmail(String to, String from, String[] cc, String subject, String body);
+    
+    /**
+     * Checks email validity and raises exception if it does not pass the test
+     * @param address
+     * @throws IllegalArgumentException if the email address provided is invalid
+     */
+    public void validateEmail(String address) {
+        if(!isValidEmail(address)) {
+            throw new IllegalArgumentException(String.format("Invalid email address: %s", address));
+        }
+    }
+    
+    /* (non-Javadoc)
+     * @see com.netflix.simianarmy.EmailClient#sendEmail(String, String, String[], String, String)
+     */
+    @Override
+    public void sendEmail(String to, String from, String[] cc, String subject, String body) {
+        try {
+            try {
+                validateEmail(to);
+            } catch(IllegalArgumentException iae) {
+                LOGGER.error(String.format("The destination email address %s is not valid,  no email is sent.", to));
+                return;
+            }
+            String messageId = buildAndSendEmail(to, from, cc, subject, body);
+            LOGGER.info(String.format("Email to %s, result id is %s, subject is %s",
+                to, messageId, subject));
+        } catch(Exception e) {
+            throw new RuntimeException(String.format("Failed to send email to %s", to), e);
+        }
+    }
+    
+    /* (non-Javadoc)
+     * @see com.netflix.simianarmy.EmailClient#isValidEmail(String)
+     */
+    @Override
+    public boolean isValidEmail(String email) {
+        if (email == null) {
+            return false;
+        }
+        if (!emailPattern.matcher(email).matches()) {
+            LOGGER.error(String.format("Invalid email address: %s", email));
+            return false;
+        }
+        if (email.equals("foo@bar.com")) {
+            LOGGER.error(String.format("Email address not changed from default; treating as invalid: %s", email));
+            return false;
+        }
+        return true;
+    }
+    
+}

--- a/src/main/java/com/netflix/simianarmy/basic/BasicEmailClient.java
+++ b/src/main/java/com/netflix/simianarmy/basic/BasicEmailClient.java
@@ -25,7 +25,7 @@ public abstract class BasicEmailClient implements EmailClient {
     protected final MonkeyConfiguration cfg;
     
     static {
-        emailPattern = Pattern.compile(EMAIL_PATTERN);;
+        emailPattern = Pattern.compile(EMAIL_PATTERN);
     }
     
     /**

--- a/src/main/java/com/netflix/simianarmy/basic/BasicSimianArmyContext.java
+++ b/src/main/java/com/netflix/simianarmy/basic/BasicSimianArmyContext.java
@@ -339,13 +339,13 @@ public class BasicSimianArmyContext implements Monkey.Context {
      * Load a class specified by the config; for drop-in replacements.
      * (Duplicates a method in MonkeyServer; refactor to util?).
      *
-     * @param clientConfig
+     * @param config
      * @param key
-     * @return
+     * @return The initialized class named by the key, or null if empty or not found
      * @throws ServletException
      */
     @SuppressWarnings("rawtypes")
-    private Class loadClientClass(BasicConfiguration config, String key) {
+    protected Class loadClientClass(BasicConfiguration config, String key) {
         ClassLoader classLoader = getClass().getClassLoader();
         try {
             String clientClassName = config.getStrOrElse(key, null);

--- a/src/main/java/com/netflix/simianarmy/basic/JakartaCommonsEmailClient.java
+++ b/src/main/java/com/netflix/simianarmy/basic/JakartaCommonsEmailClient.java
@@ -1,0 +1,76 @@
+/*
+ *
+ *  Copyright 2013 Salesforce.com, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.simianarmy.basic;
+
+
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.mail.DefaultAuthenticator;
+import org.apache.commons.mail.Email;
+import org.apache.commons.mail.SimpleEmail;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netflix.simianarmy.MonkeyConfiguration;
+import com.netflix.simianarmy.basic.BasicEmailClient;
+
+/**
+ * The class implements the EmailClient interface using the Jakarta commons email library
+ * to send email directly through an SMTP server.
+ */
+public class JakartaCommonsEmailClient extends BasicEmailClient {
+    /** The Constant LOGGER. */
+    private static final Logger LOGGER = LoggerFactory.getLogger(JakartaCommonsEmailClient.class);
+    /**
+     * The constructor.
+     */
+    public JakartaCommonsEmailClient(MonkeyConfiguration cfg) {
+        super(cfg);
+    }
+    
+    /* (non-Javadoc)
+     * @see com.netflix.simianarmy.basic.BasicEmailClient#buildAndSendEmail(String, String, String[], String, String)
+     */
+    @Override
+    protected String buildAndSendEmail(String to, String from, String[] cc, String subject, String body) {
+        Email email = new SimpleEmail();
+        email.setHostName(cfg.getStrOrElse("simianarmy.client.smtp.host", "localhost"));
+        email.setSmtpPort(Integer.parseInt(cfg.getStrOrElse("simianarmy.client.smtp.port", "25")));
+        String smtpUser = cfg.getStr("simianarmy.client.smtp.username");
+        String smtpPass = cfg.getStr("simianarmy.client.smtp.password");
+        if(smtpUser != null && smtpPass != null){
+          email.setAuthenticator(new DefaultAuthenticator(smtpUser, smtpPass));
+        }
+        email.setSubject(subject);
+        
+        String result = null;
+        try {
+            email.setFrom(from);
+            email.setMsg(body);
+            email.addTo(to);
+            if(!ArrayUtils.isEmpty(cc)) email.addCc(cc);
+            LOGGER.debug(String.format("Sending email with subject '%s' to %s",
+                subject, to));
+            result = email.send();
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage());
+        }
+        return result;
+    }
+
+}

--- a/src/main/java/com/netflix/simianarmy/basic/JakartaCommonsEmailClient.java
+++ b/src/main/java/com/netflix/simianarmy/basic/JakartaCommonsEmailClient.java
@@ -27,7 +27,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.netflix.simianarmy.MonkeyConfiguration;
-import com.netflix.simianarmy.basic.BasicEmailClient;
 
 /**
  * The class implements the EmailClient interface using the Jakarta commons email library
@@ -42,28 +41,30 @@ public class JakartaCommonsEmailClient extends BasicEmailClient {
     public JakartaCommonsEmailClient(MonkeyConfiguration cfg) {
         super(cfg);
     }
-    
+
     /* (non-Javadoc)
      * @see com.netflix.simianarmy.basic.BasicEmailClient#buildAndSendEmail(String, String, String[], String, String)
      */
     @Override
     protected String buildAndSendEmail(String to, String from, String[] cc, String subject, String body) {
         Email email = new SimpleEmail();
-        email.setHostName(cfg.getStrOrElse("simianarmy.client.smtp.host", "localhost"));
-        email.setSmtpPort(Integer.parseInt(cfg.getStrOrElse("simianarmy.client.smtp.port", "25")));
-        String smtpUser = cfg.getStr("simianarmy.client.smtp.username");
-        String smtpPass = cfg.getStr("simianarmy.client.smtp.password");
-        if(smtpUser != null && smtpPass != null){
+        email.setHostName(getCfg().getStrOrElse("simianarmy.client.smtp.host", "localhost"));
+        email.setSmtpPort(Integer.parseInt(getCfg().getStrOrElse("simianarmy.client.smtp.port", "25")));
+        String smtpUser = getCfg().getStr("simianarmy.client.smtp.username");
+        String smtpPass = getCfg().getStr("simianarmy.client.smtp.password");
+        if (smtpUser != null && smtpPass != null) {
           email.setAuthenticator(new DefaultAuthenticator(smtpUser, smtpPass));
         }
         email.setSubject(subject);
-        
+
         String result = null;
         try {
             email.setFrom(from);
             email.setMsg(body);
             email.addTo(to);
-            if(!ArrayUtils.isEmpty(cc)) email.addCc(cc);
+            if (!ArrayUtils.isEmpty(cc)) {
+                email.addCc(cc);
+            }
             LOGGER.debug(String.format("Sending email with subject '%s' to %s",
                 subject, to));
             result = email.send();

--- a/src/main/java/com/netflix/simianarmy/basic/chaos/BasicChaosEmailNotifier.java
+++ b/src/main/java/com/netflix/simianarmy/basic/chaos/BasicChaosEmailNotifier.java
@@ -53,7 +53,7 @@ public class BasicChaosEmailNotifier extends ChaosEmailNotifier {
         this.defaultEmail = defaultEmail;
         this.ccAddresses = Arrays.asList(ccAddresses);
     }
-    
+
     /**
      * Sends an email notification for a termination of instance to a global
      * email address.
@@ -63,7 +63,7 @@ public class BasicChaosEmailNotifier extends ChaosEmailNotifier {
      */
     @Override
     public void sendTerminationGlobalNotification(InstanceGroup group, String instanceId, ChaosType chaosType) {
-        String to = cfg.getStr("simianarmy.chaos.notification.global.receiverEmail");
+        String to = getCfg().getStr("simianarmy.chaos.notification.global.receiverEmail");
         if (StringUtils.isBlank(to)) {
             LOGGER.warn("Global email address was not set, but global email notification was enabled!");
             return;
@@ -93,7 +93,7 @@ public class BasicChaosEmailNotifier extends ChaosEmailNotifier {
      */
     protected String getOwnerEmail(InstanceGroup group) {
         String prop = String.format("simianarmy.chaos.%s.%s.ownerEmail", group.type(), group.name());
-        String ownerEmail = cfg.getStr(prop);
+        String ownerEmail = getCfg().getStr(prop);
         if (ownerEmail == null) {
             LOGGER.info(String.format("Property %s is not set, use the default email address %s as"
                     + " the owner email of group %s of type %s",
@@ -118,20 +118,20 @@ public class BasicChaosEmailNotifier extends ChaosEmailNotifier {
         String body = buildEmailBody(group, instanceId, chaosType);
 
         String subject;
-        boolean emailSubjectIsBody = cfg.getBoolOrElse(
+        boolean emailSubjectIsBody = getCfg().getBoolOrElse(
                 "simianarmy.chaos.notification.subject.isBody", false);
         if (emailSubjectIsBody) {
             subject = body;
         } else {
             subject = buildEmailSubject(to);
         }
-        emailClient.sendEmail(to, getSourceAddress(to), getCcAddresses(to), subject, body);
+        getEmailClient().sendEmail(to, getSourceAddress(to), getCcAddresses(to), subject, body);
     }
 
     @Override
     public String buildEmailSubject(String to) {
-        String emailSubjectPrefix = cfg.getStrOrElse("simianarmy.chaos.notification.subject.prefix", "");
-        String emailSubjectSuffix = cfg.getStrOrElse("simianarmy.chaos.notification.subject.suffix", "");
+        String emailSubjectPrefix = getCfg().getStrOrElse("simianarmy.chaos.notification.subject.prefix", "");
+        String emailSubjectSuffix = getCfg().getStrOrElse("simianarmy.chaos.notification.subject.suffix", "");
         return String.format("%sChaos Monkey Termination Notification for %s%s",
                                                 emailSubjectPrefix, to, emailSubjectSuffix);
     }
@@ -146,8 +146,8 @@ public class BasicChaosEmailNotifier extends ChaosEmailNotifier {
      * @return the created string
      */
     public String buildEmailBody(InstanceGroup group, String instanceId, ChaosType chaosType) {
-        String emailBodyPrefix = cfg.getStrOrElse("simianarmy.chaos.notification.body.prefix", "");
-        String emailBodySuffix = cfg.getStrOrElse("simianarmy.chaos.notification.body.suffix", "");
+        String emailBodyPrefix = getCfg().getStrOrElse("simianarmy.chaos.notification.body.prefix", "");
+        String emailBodySuffix = getCfg().getStrOrElse("simianarmy.chaos.notification.body.suffix", "");
         String body = emailBodyPrefix;
         body += String.format("Instance %s of %s %s is being terminated by Chaos monkey.",
                     instanceId, group.type(), group.name());
@@ -167,8 +167,8 @@ public class BasicChaosEmailNotifier extends ChaosEmailNotifier {
     @Override
     public String getSourceAddress(String to) {
         String prop = "simianarmy.chaos.notification.sourceEmail";
-        String sourceEmail = cfg.getStr(prop);
-        if (sourceEmail == null || !emailClient.isValidEmail(sourceEmail)) {
+        String sourceEmail = getCfg().getStr(prop);
+        if (sourceEmail == null || !getEmailClient().isValidEmail(sourceEmail)) {
             String msg = String.format("Property %s is not set or its value is not a valid email.", prop);
             LOGGER.error(msg);
             throw new RuntimeException(msg);
@@ -176,5 +176,4 @@ public class BasicChaosEmailNotifier extends ChaosEmailNotifier {
         return sourceEmail;
     }
 
-    
 }

--- a/src/main/java/com/netflix/simianarmy/chaos/ChaosEmailNotifier.java
+++ b/src/main/java/com/netflix/simianarmy/chaos/ChaosEmailNotifier.java
@@ -19,8 +19,6 @@ package com.netflix.simianarmy.chaos;
 
 import java.lang.reflect.Constructor;
 
-import javax.servlet.ServletException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,12 +33,16 @@ import com.netflix.simianarmy.chaos.ChaosCrawler.InstanceGroup;
  *
  */
 public abstract class ChaosEmailNotifier implements MonkeyEmailNotifier {
-    protected EmailClient emailClient;
+    private EmailClient emailClient;
     private static final Logger LOGGER = LoggerFactory.getLogger(ChaosEmailNotifier.class);
 
-    protected final MonkeyConfiguration cfg;
-    
-    /** Constructor. 
+    private final MonkeyConfiguration cfg;
+
+    public MonkeyConfiguration getCfg() {
+        return cfg;
+    }
+
+    /** Constructor.
      *
      * @param cfg the monkey configuration used to initialize the email notifier.
      */
@@ -48,19 +50,22 @@ public abstract class ChaosEmailNotifier implements MonkeyEmailNotifier {
         this.cfg = cfg;
         createEmailClient();
     }
-    
+
+    /**
+     * Instantiates the email client to handle transport of mail.
+     */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     protected void createEmailClient() {
-        BasicConfiguration config = (BasicConfiguration)cfg;
+        BasicConfiguration config = (BasicConfiguration) cfg;
         Class emailClientClass = loadClientClass(config, "simianarmy.client.email.class");
         if (emailClientClass == null || emailClientClass.equals(AWSEmailClient.class)) {
             AWSEmailClient awsEmailClient = new AWSEmailClient();
             setEmailClient(awsEmailClient);
         } else {
-            setEmailClient(( (EmailClient) factory(emailClientClass, config)));
+            setEmailClient(((EmailClient) factory(emailClientClass, config)));
         }
     }
-    
+
     public EmailClient getEmailClient() {
         return emailClient;
     }
@@ -68,7 +73,7 @@ public abstract class ChaosEmailNotifier implements MonkeyEmailNotifier {
     public void setEmailClient(EmailClient emailClient) {
         this.emailClient = emailClient;
     }
-    
+
     /**
      * Load a class specified by the config; for drop-in replacements.
      * (Duplicates a method in MonkeyServer; refactor to util?).
@@ -76,7 +81,6 @@ public abstract class ChaosEmailNotifier implements MonkeyEmailNotifier {
      * @param config
      * @param key
      * @return The initialized class named in by the key, or null if empty or not found
-     * @throws ServletException
      */
     @SuppressWarnings("rawtypes")
     protected Class loadClientClass(BasicConfiguration config, String key) {

--- a/src/main/resources/client.properties
+++ b/src/main/resources/client.properties
@@ -45,3 +45,10 @@ simianarmy.client.aws.region = us-west-1
 ### (specify ASG names as usual with no suffix in chaos.properties)  
 #
 #simianarmy.client.chaos.class=com.netflix.simianarmy.basic.chaos.CloudFormationChaosMonkey
+
+# Uncomment to use a version of the email notifier that does not rely on AWS Email services
+#simianarmy.client.email.class=com.netflix.simianarmy.basic.JakartaCommonsEmailClient
+#simianarmy.client.smtp.host=localhost
+#simianarmy.client.smtp.port=25
+#simianarmy.client.smtp.username=kong
+#simianarmy.client.smtp.password=skullisland

--- a/src/test/java/com/netflix/simianarmy/basic/chaos/TestBasicChaosEmailNotifier.java
+++ b/src/test/java/com/netflix/simianarmy/basic/chaos/TestBasicChaosEmailNotifier.java
@@ -131,34 +131,35 @@ public class TestBasicChaosEmailNotifier {
         String subject = basicChaosEmailNotifier.buildEmailBody(testInstanceGroup, instanceId, null);
         Assert.assertEquals(subject, bodyPrefix + defaultBody + bodySuffix);
     }
-    
-    /** 
+
+    /**
      * Test to verify that specifying a specific email client implementation works and that
      * the default is not selected
      */
     @Test
     public void testUsesJakartaCommonsEmailClient() {
         properties.setProperty("simianarmy.chaos.notification.sourceEmail", to);
-        properties.setProperty("simianarmy.client.email.class", "com.netflix.simianarmy.basic.JakartaCommonsEmailClient");
-        BasicChaosEmailNotifier basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(
+        properties.setProperty("simianarmy.client.email.class",
+            "com.netflix.simianarmy.basic.JakartaCommonsEmailClient");
+        basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(
             properties), null);
-        Assert.assertEquals(basicChaosEmailNotifier.getEmailClient().getClass(), 
+        Assert.assertEquals(basicChaosEmailNotifier.getEmailClient().getClass(),
             JakartaCommonsEmailClient.class);
     }
-    
-    /** 
+
+    /**
      * Test to verify that NOT specifying a specific email causes the default to be selected
      */
     @Test
     public void testUsesAWSEmailClient() {
         properties.setProperty("simianarmy.chaos.notification.sourceEmail", to);
-        BasicChaosEmailNotifier basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(
+        basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(
             properties), null);
-        Assert.assertEquals(basicChaosEmailNotifier.getEmailClient().getClass(), 
+        Assert.assertEquals(basicChaosEmailNotifier.getEmailClient().getClass(),
             AWSEmailClient.class);
     }
-    
-    /** 
+
+    /**
      * Test that the SMTP client actually works and sends an email. Rather than using mocks of a lower level
      * class that is essentially auto-wired, this is more of an integration test.  In the test,
      * we spin up an in-memory SMTP server running on port 2500 (if you run it on 25, the default SMTP port,
@@ -168,29 +169,30 @@ public class TestBasicChaosEmailNotifier {
     @Test
     public void testBuildAndSendEmailForReal() {
         Wiser wiser = new Wiser();
-        try { 
+        try {
             wiser.setPort(2500); // Default is 25
             wiser.start();
             properties.setProperty("simianarmy.chaos.notification.sourceEmail", "mightyjoeyoung@simianarmy.com");
-            properties.setProperty("simianarmy.client.email.class", "com.netflix.simianarmy.basic.JakartaCommonsEmailClient");
+            properties.setProperty("simianarmy.client.email.class",
+                "com.netflix.simianarmy.basic.JakartaCommonsEmailClient");
             properties.setProperty("simianarmy.client.smtp.port", "2500");
             String toReal = "bonzo@simianarmy.com";
-            BasicChaosEmailNotifier basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(
+            basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(
                 properties), null);
             BasicChaosEmailNotifier spyBasicChaosEmailNotifier = spy(basicChaosEmailNotifier);
             spyBasicChaosEmailNotifier.buildAndSendEmail(toReal, testInstanceGroup, instanceId, null);
             verify(spyBasicChaosEmailNotifier).buildAndSendEmail(toReal, testInstanceGroup, instanceId, null);
             Assert.assertEquals(wiser.getMessages().size(), 1);
-        }finally {
+        } finally {
             wiser.stop();
         }
     }
-    
+
     @Test
     public void testBuildAndSendEmail() {
         String toReal = "bonzo@simianarmy.com";
         properties.setProperty("simianarmy.chaos.notification.sourceEmail", toReal);
-        BasicChaosEmailNotifier basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(
+        basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(
             properties), null);
         BasicChaosEmailNotifier spyBasicChaosEmailNotifier = spy(basicChaosEmailNotifier);
         doNothing().when(spyBasicChaosEmailNotifier).buildAndSendEmail(toReal, testInstanceGroup, instanceId, null);
@@ -202,7 +204,7 @@ public class TestBasicChaosEmailNotifier {
     public void testBuildAndSendEmailSubjectIsBody() {
         properties.setProperty("simianarmy.chaos.notification.subject.isBody", "true");
         properties.setProperty("simianarmy.chaos.notification.sourceEmail", to);
-        BasicChaosEmailNotifier basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(
+        basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(
             properties), null);
         BasicChaosEmailNotifier spyBasicChaosEmailNotifier = spy(basicChaosEmailNotifier);
         doNothing().when(spyBasicChaosEmailNotifier).buildAndSendEmail(to, testInstanceGroup, instanceId, null);

--- a/src/test/java/com/netflix/simianarmy/basic/chaos/TestBasicChaosEmailNotifier.java
+++ b/src/test/java/com/netflix/simianarmy/basic/chaos/TestBasicChaosEmailNotifier.java
@@ -24,18 +24,19 @@ import static org.mockito.Mockito.verify;
 
 import java.util.Properties;
 
+
+import org.subethamail.wiser.Wiser;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient;
 import com.netflix.simianarmy.GroupType;
+import com.netflix.simianarmy.aws.AWSEmailClient;
 import com.netflix.simianarmy.basic.BasicConfiguration;
+import com.netflix.simianarmy.basic.JakartaCommonsEmailClient;
 import com.netflix.simianarmy.chaos.TestChaosMonkeyContext.TestInstanceGroup;
 
 public class TestBasicChaosEmailNotifier {
-
-    private final AmazonSimpleEmailServiceClient sesClient = new AmazonSimpleEmailServiceClient();
 
     private BasicChaosEmailNotifier basicChaosEmailNotifier;
 
@@ -69,7 +70,7 @@ public class TestBasicChaosEmailNotifier {
 
     @Test
     public void testbuildEmailSubject() {
-        basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(properties), sesClient, null);
+        basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(properties), null);
         String subject = basicChaosEmailNotifier.buildEmailSubject(to);
         Assert.assertEquals(subject, defaultSubject);
     }
@@ -77,7 +78,7 @@ public class TestBasicChaosEmailNotifier {
     @Test
     public void testbuildEmailSubjectWithSubjectPrefix() {
         properties.setProperty("simianarmy.chaos.notification.subject.prefix", subjectPrefix);
-        basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(properties), sesClient, null);
+        basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(properties), null);
         String subject = basicChaosEmailNotifier.buildEmailSubject(to);
         Assert.assertEquals(subject, subjectPrefix + defaultSubject);
     }
@@ -85,7 +86,7 @@ public class TestBasicChaosEmailNotifier {
     @Test
     public void testbuildEmailSubjectWithSubjectSuffix() {
         properties.setProperty("simianarmy.chaos.notification.subject.suffix", subjectSuffix);
-        basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(properties), sesClient, null);
+        basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(properties), null);
         String subject = basicChaosEmailNotifier.buildEmailSubject(to);
         Assert.assertEquals(subject, defaultSubject + subjectSuffix);
     }
@@ -94,14 +95,14 @@ public class TestBasicChaosEmailNotifier {
     public void testbuildEmailSubjectWithSubjectPrefixSuffix() {
         properties.setProperty("simianarmy.chaos.notification.subject.prefix", subjectPrefix);
         properties.setProperty("simianarmy.chaos.notification.subject.suffix", subjectSuffix);
-        basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(properties), sesClient, null);
+        basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(properties), null);
         String subject = basicChaosEmailNotifier.buildEmailSubject(to);
         Assert.assertEquals(subject, subjectPrefix + defaultSubject + subjectSuffix);
     }
 
     @Test
     public void testbuildEmailBody() {
-        basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(properties), sesClient, null);
+        basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(properties), null);
         String subject = basicChaosEmailNotifier.buildEmailBody(testInstanceGroup, instanceId, null);
         Assert.assertEquals(subject, defaultBody);
     }
@@ -109,7 +110,7 @@ public class TestBasicChaosEmailNotifier {
     @Test
     public void testbuildEmailBodyPrefix() {
         properties.setProperty("simianarmy.chaos.notification.body.prefix", bodyPrefix);
-        basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(properties), sesClient, null);
+        basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(properties), null);
         String subject = basicChaosEmailNotifier.buildEmailBody(testInstanceGroup, instanceId, null);
         Assert.assertEquals(subject, bodyPrefix + defaultBody);
     }
@@ -117,7 +118,7 @@ public class TestBasicChaosEmailNotifier {
     @Test
     public void testbuildEmailBodySuffix() {
         properties.setProperty("simianarmy.chaos.notification.body.suffix", bodySuffix);
-        basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(properties), sesClient, null);
+        basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(properties), null);
         String subject = basicChaosEmailNotifier.buildEmailBody(testInstanceGroup, instanceId, null);
         Assert.assertEquals(subject, defaultBody + bodySuffix);
     }
@@ -126,30 +127,87 @@ public class TestBasicChaosEmailNotifier {
     public void testbuildEmailBodyPrefixSuffix() {
         properties.setProperty("simianarmy.chaos.notification.body.prefix", bodyPrefix);
         properties.setProperty("simianarmy.chaos.notification.body.suffix", bodySuffix);
-        basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(properties), sesClient, null);
+        basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(properties), null);
         String subject = basicChaosEmailNotifier.buildEmailBody(testInstanceGroup, instanceId, null);
         Assert.assertEquals(subject, bodyPrefix + defaultBody + bodySuffix);
     }
-
+    
+    /** 
+     * Test to verify that specifying a specific email client implementation works and that
+     * the default is not selected
+     */
+    @Test
+    public void testUsesJakartaCommonsEmailClient() {
+        properties.setProperty("simianarmy.chaos.notification.sourceEmail", to);
+        properties.setProperty("simianarmy.client.email.class", "com.netflix.simianarmy.basic.JakartaCommonsEmailClient");
+        BasicChaosEmailNotifier basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(
+            properties), null);
+        Assert.assertEquals(basicChaosEmailNotifier.getEmailClient().getClass(), 
+            JakartaCommonsEmailClient.class);
+    }
+    
+    /** 
+     * Test to verify that NOT specifying a specific email causes the default to be selected
+     */
+    @Test
+    public void testUsesAWSEmailClient() {
+        properties.setProperty("simianarmy.chaos.notification.sourceEmail", to);
+        BasicChaosEmailNotifier basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(
+            properties), null);
+        Assert.assertEquals(basicChaosEmailNotifier.getEmailClient().getClass(), 
+            AWSEmailClient.class);
+    }
+    
+    /** 
+     * Test that the SMTP client actually works and sends an email. Rather than using mocks of a lower level
+     * class that is essentially auto-wired, this is more of an integration test.  In the test,
+     * we spin up an in-memory SMTP server running on port 2500 (if you run it on 25, the default SMTP port,
+     * you may see a SecurityException because you're trying to run a server on a low-numbered port).
+     * The server does not deliver mail.  It stores it for examination at the end of the test.
+     */
+    @Test
+    public void testBuildAndSendEmailForReal() {
+        Wiser wiser = new Wiser();
+        try { 
+            wiser.setPort(2500); // Default is 25
+            wiser.start();
+            properties.setProperty("simianarmy.chaos.notification.sourceEmail", "mightyjoeyoung@simianarmy.com");
+            properties.setProperty("simianarmy.client.email.class", "com.netflix.simianarmy.basic.JakartaCommonsEmailClient");
+            properties.setProperty("simianarmy.client.smtp.port", "2500");
+            String toReal = "bonzo@simianarmy.com";
+            BasicChaosEmailNotifier basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(
+                properties), null);
+            BasicChaosEmailNotifier spyBasicChaosEmailNotifier = spy(basicChaosEmailNotifier);
+            spyBasicChaosEmailNotifier.buildAndSendEmail(toReal, testInstanceGroup, instanceId, null);
+            verify(spyBasicChaosEmailNotifier).buildAndSendEmail(toReal, testInstanceGroup, instanceId, null);
+            Assert.assertEquals(wiser.getMessages().size(), 1);
+        }finally {
+            wiser.stop();
+        }
+    }
+    
     @Test
     public void testBuildAndSendEmail() {
-        properties.setProperty("simianarmy.chaos.notification.sourceEmail", to);
-        BasicChaosEmailNotifier spyBasicChaosEmailNotifier = spy(new BasicChaosEmailNotifier(new BasicConfiguration(
-                properties), sesClient, null));
-        doNothing().when(spyBasicChaosEmailNotifier).sendEmail(to, defaultSubject, defaultBody);
-        spyBasicChaosEmailNotifier.buildAndSendEmail(to, testInstanceGroup, instanceId, null);
-        verify(spyBasicChaosEmailNotifier).sendEmail(to, defaultSubject, defaultBody);
+        String toReal = "bonzo@simianarmy.com";
+        properties.setProperty("simianarmy.chaos.notification.sourceEmail", toReal);
+        BasicChaosEmailNotifier basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(
+            properties), null);
+        BasicChaosEmailNotifier spyBasicChaosEmailNotifier = spy(basicChaosEmailNotifier);
+        doNothing().when(spyBasicChaosEmailNotifier).buildAndSendEmail(toReal, testInstanceGroup, instanceId, null);
+        spyBasicChaosEmailNotifier.buildAndSendEmail(toReal, testInstanceGroup, instanceId, null);
+        verify(spyBasicChaosEmailNotifier).buildAndSendEmail(toReal, testInstanceGroup, instanceId, null);
     }
 
     @Test
     public void testBuildAndSendEmailSubjectIsBody() {
         properties.setProperty("simianarmy.chaos.notification.subject.isBody", "true");
         properties.setProperty("simianarmy.chaos.notification.sourceEmail", to);
-        BasicChaosEmailNotifier spyBasicChaosEmailNotifier = spy(new BasicChaosEmailNotifier(new BasicConfiguration(
-                properties), sesClient, null));
-        doNothing().when(spyBasicChaosEmailNotifier).sendEmail(to, defaultBody, defaultBody);
+        BasicChaosEmailNotifier basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(
+            properties), null);
+        BasicChaosEmailNotifier spyBasicChaosEmailNotifier = spy(basicChaosEmailNotifier);
+        doNothing().when(spyBasicChaosEmailNotifier).buildAndSendEmail(to, testInstanceGroup, instanceId, null);
         spyBasicChaosEmailNotifier.buildAndSendEmail(to, testInstanceGroup, instanceId, null);
-        verify(spyBasicChaosEmailNotifier).sendEmail(to, defaultBody, defaultBody);
+        verify(spyBasicChaosEmailNotifier).buildAndSendEmail(to, testInstanceGroup, instanceId, null);
     }
 
 }

--- a/src/test/java/com/netflix/simianarmy/chaos/TestChaosMonkeyContext.java
+++ b/src/test/java/com/netflix/simianarmy/chaos/TestChaosMonkeyContext.java
@@ -421,7 +421,7 @@ public class TestChaosMonkeyContext extends TestMonkeyContext implements ChaosMo
 
     @Override
     public ChaosEmailNotifier chaosEmailNotifier() {
-        return new ChaosEmailNotifier(null) {
+        return new ChaosEmailNotifier(cfg) {
             @Override
             public String getSourceAddress(String to) {
                 return "source@chaosMonkey.foo";


### PR DESCRIPTION
This request contains one commit that was merged in from SimianArmy on Netflix:master (removal of java 1.6 requirement).  Tests run (and new tests written), no regressions.  Comments welcome!

The purpose of this PR is to start work on abstraction of "cloud" and "cluster" ideas (all still abstract) from some of the tightly coupled AWS dependencies that exist in those base classes.  This particular branch allows a non-aws user to send notifications through a specified SMTP server.  Our particular use case is that we _are_ a cloud provider (rather than an app developer who deploys _to_ a cloud provider).  SimianArmy has the same intrinsic value for cloud providers (taking out machines to see if the cluster will survive without interrupting the user experience), but we obviously can't route mail through the AWS email service.