### PR TITLE
Refactor reading of chaos monkey properties and defaults values

### DIFF
--- a/src/test/resources/com/netflix/simianarmy/chaos/propertiesWithDefaults.properties
+++ b/src/test/resources/com/netflix/simianarmy/chaos/propertiesWithDefaults.properties
@@ -1,0 +1,7 @@
+simianarmy.chaos.leashed = false
+simianarmy.chaos.TYPE_A.enabled = true
+simianarmy.chaos.TYPE_A.probability = 1.0
+simianarmy.chaos.TYPE_A.maxTerminationsPerDay = 2.0
+simianarmy.chaos.TYPE_A.named1.enabled = false
+simianarmy.chaos.TYPE_A.named1.probability = 1.1
+simianarmy.chaos.TYPE_A.named1.maxTerminationsPerDay = 2.1


### PR DESCRIPTION
Refactoring out the reading of 'enabled', 'maxTerminationsPerDay', and 'probability' into a separate method. The method also handles reading the default values from the group level if one doesn't exist at the named group level. The reason for the refactor is to override the way defaults are read internally at netflix.
