### PR TITLE
PZ add org.jclouds.api:ec2:1.6.0 dependency to fix chaos type issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     compile 'org.apache.httpcomponents:httpcore:4.2.1'
     compile 'org.jclouds.driver:jclouds-jsch:1.6.0'
     compile 'org.jclouds.driver:jclouds-slf4j:1.6.0'
+    compile 'org.jclouds.api:ec2:1.6.0'
 
     testCompile 'org.testng:testng:6.3.1'
     testCompile 'org.mockito:mockito-core:1.8.5'


### PR DESCRIPTION
Currently if you enable CPU burn chaos type, the chaos monkey will give an error when check if SSH can be created. The error is caused because the ec2 jar is missing from jclouds context builder.
Error details:... [ec2] not found org.jclouds.ContextBuilder.newBuilder
