### PR TITLE
Fixed cobertura reports

### DIFF
--- a/gradle/check.gradle
+++ b/gradle/check.gradle
@@ -17,8 +17,5 @@ apply plugin: 'pmd'
 
 apply plugin: 'cobertura'
 cobertura {
-    sourceDirs = sourceSets.main.java.srcDirs
-    format = 'xml'
-    includes = ['**/*.java', '**/*.groovy']
-    excludes = []
+    coverageFormats = ['xml']
 }


### PR DESCRIPTION
This should fix broken cobertura reports after gradle plugin upgrade.
