### PR TITLE
The original condition should be returned in addition to the new one sin...

### DIFF
--- a/src/main/java/com/netflix/simianarmy/basic/chaos/BasicChaosMonkey.java
+++ b/src/main/java/com/netflix/simianarmy/basic/chaos/BasicChaosMonkey.java
@@ -109,6 +109,9 @@ public class BasicChaosMonkey extends ChaosMonkey {
             }
             for (InstanceGroup group : context().chaosCrawler().groups()) {
                 if (isGroupEnabled(group)) {
+                    if (isMaxTerminationCountExceeded(group)) {
+                        continue;
+                    }
                     double prob = getEffectiveProbability(group);
                     Collection<String> instances = context().chaosInstanceSelector().select(group, prob / runsPerDay);
                     for (String inst : instances) {


### PR DESCRIPTION
...ce unit-test will otherwise fail:

the reason for that is that the unit-test checks two things:
1. selected instances
2. terminated

and no instance should be selected if we reached the max.
Though the previous fix ensures that we won’t kill the chosen instance - according to the unit-test we should not even choose it (strict approach).
