### PR TITLE
Don't take false MonkeyTime property.

### DIFF
--- a/src/main/java/com/netflix/simianarmy/basic/BasicCalendar.java
+++ b/src/main/java/com/netflix/simianarmy/basic/BasicCalendar.java
@@ -100,8 +100,10 @@ public class BasicCalendar implements MonkeyCalendar {
     /** {@inheritDoc} */
     @Override
     public boolean isMonkeyTime(Monkey monkey) {
-        if (cfg != null && cfg.getStrOrElse("simianarmy.calendar.isMonkeyTime", null) != null) {
-            return cfg.getBool("simianarmy.calendar.isMonkeyTime");
+        if (cfg != null
+            && cfg.getStrOrElse("simianarmy.calendar.isMonkeyTime", null) != null
+            && cfg.getBool("simianarmy.calendar.isMonkeyTime")) {
+            return true;
         }
 
         Calendar now = now();


### PR DESCRIPTION
Before, the `simianarmy.calendar.isMonkeyTime` could have *three* states: true, false, or unset. If unset, the property is ignored; if true, it's always monkey time; if false, it's never monkey time.

Arguably, given the documentation, this is the correct behavior.