### PR TITLE
Set region when using SES.

### DIFF
--- a/src/main/java/com/netflix/simianarmy/basic/BasicChaosMonkeyContext.java
+++ b/src/main/java/com/netflix/simianarmy/basic/BasicChaosMonkeyContext.java
@@ -17,6 +17,8 @@
  */
 package com.netflix.simianarmy.basic;
 
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient;
 import com.netflix.simianarmy.MonkeyConfiguration;
 import com.netflix.simianarmy.basic.chaos.BasicChaosEmailNotifier;
@@ -51,7 +53,9 @@ public class BasicChaosMonkeyContext extends BasicSimianArmyContext implements C
         setChaosCrawler(new ASGChaosCrawler(awsClient()));
         setChaosInstanceSelector(new BasicChaosInstanceSelector());
         MonkeyConfiguration cfg = configuration();
-        setChaosEmailNotifier(new BasicChaosEmailNotifier(cfg, new AmazonSimpleEmailServiceClient(), null));
+        AmazonSimpleEmailServiceClient sesClient = new AmazonSimpleEmailServiceClient();
+        sesClient.setRegion(Region.getRegion(Regions.fromName(region())));
+        setChaosEmailNotifier(new BasicChaosEmailNotifier(cfg, sesClient, null));
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/com/netflix/simianarmy/basic/conformity/BasicConformityMonkeyContext.java
+++ b/src/main/java/com/netflix/simianarmy/basic/conformity/BasicConformityMonkeyContext.java
@@ -17,6 +17,8 @@
 // CHECKSTYLE IGNORE MagicNumberCheck
 package com.netflix.simianarmy.basic.conformity;
 
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -162,6 +164,7 @@ public class BasicConformityMonkeyContext extends BasicSimianArmyContext impleme
 
         clusterCrawler = new AWSClusterCrawler(regionToAwsClient, configuration());
         sesClient = new AmazonSimpleEmailServiceClient();
+        sesClient.setRegion(Region.getRegion(Regions.fromName(region())));
         defaultEmail = configuration().getStrOrElse("simianarmy.conformity.notification.defaultEmail", null);
         ccEmails = StringUtils.split(
                 configuration().getStrOrElse("simianarmy.conformity.notification.ccEmails", ""), ",");

--- a/src/main/java/com/netflix/simianarmy/basic/janitor/BasicJanitorMonkeyContext.java
+++ b/src/main/java/com/netflix/simianarmy/basic/janitor/BasicJanitorMonkeyContext.java
@@ -17,6 +17,8 @@
 // CHECKSTYLE IGNORE MagicNumberCheck
 package com.netflix.simianarmy.basic.janitor;
 
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient;
 import com.netflix.discovery.DiscoveryManager;
 import com.netflix.simianarmy.MonkeyCalendar;
@@ -120,6 +122,7 @@ public class BasicJanitorMonkeyContext extends BasicSimianArmyContext implements
 
         janitorEmailBuilder = new BasicJanitorEmailBuilder();
         sesClient = new AmazonSimpleEmailServiceClient();
+        sesClient.setRegion(Region.getRegion(Regions.fromName(monkeyRegion)));
         defaultEmail = configuration().getStrOrElse("simianarmy.janitor.notification.defaultEmail", "");
         ccEmails = StringUtils.split(
                 configuration().getStrOrElse("simianarmy.janitor.notification.ccEmails", ""), ",");


### PR DESCRIPTION
We ran into the issue where sending mail kept failing, even after we enabled production access for SES and verified the sender email address. The issue turned out that by default SimianArmy was using us-east-1 for SES, but the region we were operating in (and had production access/verified emails) was us-west-2.

It might be more sensible to use a property for controlling what region the SES client uses, but this works for us.