### PR TITLE
Add optional proxy configuration to client.properties

### DIFF
--- a/src/main/java/com/netflix/simianarmy/aws/STSAssumeRoleSessionCredentialsProvider.java
+++ b/src/main/java/com/netflix/simianarmy/aws/STSAssumeRoleSessionCredentialsProvider.java
@@ -70,6 +70,22 @@ public class STSAssumeRoleSessionCredentialsProvider implements AWSCredentialsPr
     }
 
     /**
+     * Constructs a new STSAssumeRoleSessionCredentialsProvider, which makes a
+     * request to the AWS Security Token Service (STS), uses the provided
+     * {@link #roleArn} to assume a role and then request short lived session
+     * credentials, which will then be returned by this class's
+     * {@link #getCredentials()} method.
+     * @param roleArn
+     *            The AWS ARN of the Role to be assumed.
+     * @param clientConfiguration
+     *            The AWS ClientConfiguration to use when making AWS API requests.
+     */
+    public STSAssumeRoleSessionCredentialsProvider(String roleArn, ClientConfiguration clientConfiguration) {
+        this.roleArn = roleArn;
+        securityTokenService = new AWSSecurityTokenServiceClient(clientConfiguration);
+    }
+
+    /**
      * Constructs a new STSAssumeRoleSessionCredentialsProvider, which will use
      * the specified long lived AWS credentials to make a request to the AWS
      * Security Token Service (STS), uses the provided {@link #roleArn} to

--- a/src/main/java/com/netflix/simianarmy/client/aws/AWSClient.java
+++ b/src/main/java/com/netflix/simianarmy/client/aws/AWSClient.java
@@ -18,6 +18,7 @@
 package com.netflix.simianarmy.client.aws;
 
 import com.amazonaws.AmazonServiceException;
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.autoscaling.AmazonAutoScalingClient;
 import com.amazonaws.services.autoscaling.model.AutoScalingGroup;
@@ -116,6 +117,8 @@ public class AWSClient implements CloudClient {
 
     private final AWSCredentialsProvider awsCredentialsProvider;
 
+    private final ClientConfiguration awsClientConfig;
+
     private ComputeService jcloudsComputeService;
 
     /**
@@ -153,6 +156,7 @@ public class AWSClient implements CloudClient {
     public AWSClient(String region) {
         this.region = region;
         this.awsCredentialsProvider = null;
+        this.awsClientConfig = null;
     }
 
     /**
@@ -165,6 +169,35 @@ public class AWSClient implements CloudClient {
     public AWSClient(String region, AWSCredentialsProvider awsCredentialsProvider) {
         this.region = region;
         this.awsCredentialsProvider = awsCredentialsProvider;
+        this.awsClientConfig = null;
+    }
+
+    /**
+     * The constructor allows you to provide your own AWS client configuration.
+     * @param region
+     *          the region
+     * @param awsClientConfig
+     *          the AWS client configuration
+     */
+    public AWSClient(String region, ClientConfiguration awsClientConfig) {
+        this.region = region;
+        this.awsCredentialsProvider = null;
+        this.awsClientConfig = awsClientConfig;
+    }
+
+    /**
+     * The constructor allows you to provide your own AWS credentials provider and client config.
+     * @param region
+     *          the region
+     * @param awsCredentialsProvider
+     *          the AWS credentials provider
+     * @param awsClientConfig
+     *          the AWS client configuration
+     */
+    public AWSClient(String region, AWSCredentialsProvider awsCredentialsProvider, ClientConfiguration awsClientConfig) {
+        this.region = region;
+        this.awsCredentialsProvider = awsCredentialsProvider;
+        this.awsClientConfig = awsClientConfig;
     }
 
     /**
@@ -183,10 +216,18 @@ public class AWSClient implements CloudClient {
      */
     protected AmazonEC2 ec2Client() {
         AmazonEC2 client;
-        if (awsCredentialsProvider == null) {
-            client = new AmazonEC2Client();
+        if (awsClientConfig == null) {
+            if (awsCredentialsProvider == null) {
+                client = new AmazonEC2Client();
+            } else {
+                client = new AmazonEC2Client(awsCredentialsProvider);
+            }
         } else {
-            client = new AmazonEC2Client(awsCredentialsProvider);
+            if (awsCredentialsProvider == null) {
+                client = new AmazonEC2Client(awsClientConfig);
+            } else {
+                client = new AmazonEC2Client(awsCredentialsProvider, awsClientConfig);
+            }
         }
         client.setEndpoint("ec2." + region + ".amazonaws.com");
         return client;
@@ -199,10 +240,18 @@ public class AWSClient implements CloudClient {
      */
     protected AmazonAutoScalingClient asgClient() {
         AmazonAutoScalingClient client;
-        if (awsCredentialsProvider == null) {
-            client = new AmazonAutoScalingClient();
+        if (awsClientConfig == null) {
+            if (awsCredentialsProvider == null) {
+                client = new AmazonAutoScalingClient();
+            } else {
+                client = new AmazonAutoScalingClient(awsCredentialsProvider);
+            }
         } else {
-            client = new AmazonAutoScalingClient(awsCredentialsProvider);
+            if (awsCredentialsProvider == null) {
+                client = new AmazonAutoScalingClient(awsClientConfig);
+            } else {
+                client = new AmazonAutoScalingClient(awsCredentialsProvider, awsClientConfig);
+            }
         }
         client.setEndpoint("autoscaling." + region + ".amazonaws.com");
         return client;
@@ -215,10 +264,18 @@ public class AWSClient implements CloudClient {
      */
     protected AmazonElasticLoadBalancingClient elbClient() {
         AmazonElasticLoadBalancingClient client;
-        if (awsCredentialsProvider == null) {
-            client = new AmazonElasticLoadBalancingClient();
+        if (awsClientConfig == null) {
+            if (awsCredentialsProvider == null) {
+                client = new AmazonElasticLoadBalancingClient();
+            } else {
+                client = new AmazonElasticLoadBalancingClient(awsCredentialsProvider);
+            }
         } else {
-            client = new AmazonElasticLoadBalancingClient(awsCredentialsProvider);
+            if (awsCredentialsProvider == null) {
+                client = new AmazonElasticLoadBalancingClient(awsClientConfig);
+            } else {
+                client = new AmazonElasticLoadBalancingClient(awsCredentialsProvider, awsClientConfig);
+            }
         }
         client.setEndpoint("elasticloadbalancing." + region + ".amazonaws.com");
         return client;
@@ -231,10 +288,18 @@ public class AWSClient implements CloudClient {
      */
     public AmazonSimpleDB sdbClient() {
         AmazonSimpleDB client;
-        if (awsCredentialsProvider == null) {
-            client = new AmazonSimpleDBClient();
+        if (awsClientConfig == null) {
+            if (awsCredentialsProvider == null) {
+                client = new AmazonSimpleDBClient();
+            } else {
+                client = new AmazonSimpleDBClient(awsCredentialsProvider);
+            }
         } else {
-            client = new AmazonSimpleDBClient(awsCredentialsProvider);
+            if (awsCredentialsProvider == null) {
+                client = new AmazonSimpleDBClient(awsClientConfig);
+            } else {
+                client = new AmazonSimpleDBClient(awsCredentialsProvider, awsClientConfig);
+            }
         }
         // us-east-1 has special naming
         // http://docs.amazonwebservices.com/general/latest/gr/rande.html#sdb_region

--- a/src/main/java/com/netflix/simianarmy/client/aws/AWSClient.java
+++ b/src/main/java/com/netflix/simianarmy/client/aws/AWSClient.java
@@ -375,9 +375,9 @@ public class AWSClient implements CloudClient {
     }
 
     /**
-     * Describe a set of specific ELBs.
+     * Describe a specific ELB.
      *
-     * @param names the ELB names
+     * @param name the ELB names
      * @return the ELBs
      */
     public LoadBalancerAttributes describeElasticLoadBalancerAttributes(String name) {

--- a/src/main/resources/client.properties
+++ b/src/main/resources/client.properties
@@ -45,3 +45,10 @@ simianarmy.client.aws.region = us-west-1
 ### (specify ASG names as usual with no suffix in chaos.properties)  
 #
 #simianarmy.client.chaos.class=com.netflix.simianarmy.basic.chaos.CloudFormationChaosMonkey
+
+# Use the following if a proxy is needed to connect to AWS APIs
+# proxyHost and proxyPort are required to connect through a proxy, proxyUser and proxyPassword are optional
+#simianarmy.client.aws.proxyHost=
+#simianarmy.client.aws.proxyPort=
+#simianarmy.client.aws.proxyUser=
+#simianarmy.client.aws.proxyPassword=


### PR DESCRIPTION
(aka "Let the Monkeys rampage by proxy")

This patch adds the following optional proxy configuration to client.properties:

```java
simianarmy.client.aws.proxyHost=internal-proxy.example.com
simianarmy.client.aws.proxyPort=1234
simianarmy.client.aws.proxyUser=optionalUser
simianarmy.client.aws.proxyPassword=optionalPassword
```

Which are then used when configuring the various Amazon clients used within the project.

Fixes #150 
