### PR TITLE
Add accountName to emails from Janitor Monkey

### DIFF
--- a/src/main/java/com/netflix/simianarmy/basic/BasicSimianArmyContext.java
+++ b/src/main/java/com/netflix/simianarmy/basic/BasicSimianArmyContext.java
@@ -80,6 +80,8 @@ public class BasicSimianArmyContext implements Monkey.Context {
     /** If configured, the ARN of Role to be assumed. */
     private final String assumeRoleArn;
 
+    private final String accountName;
+
     private final String account;
 
     private final String secret;
@@ -103,6 +105,7 @@ public class BasicSimianArmyContext implements Monkey.Context {
 
         account = config.getStr("simianarmy.client.aws.accountKey");
         secret = config.getStr("simianarmy.client.aws.secretKey");
+        accountName = config.getStrOrElse("simianarmy.client.aws.accountName", "Default");
         region = config.getStrOrElse("simianarmy.client.aws.region", "us-east-1");
 
         assumeRoleArn = config.getStr("simianarmy.client.aws.assumeRoleArn");
@@ -195,6 +198,14 @@ public class BasicSimianArmyContext implements Monkey.Context {
      */
     public String region() {
         return region;
+    }
+
+    /**
+     * Gets the accountName
+     * @return the accountName
+     */
+    public String accountName() {
+        return accountName;
     }
 
     @Override

--- a/src/main/java/com/netflix/simianarmy/basic/janitor/BasicJanitorMonkey.java
+++ b/src/main/java/com/netflix/simianarmy/basic/janitor/BasicJanitorMonkey.java
@@ -53,6 +53,8 @@ public class BasicJanitorMonkey extends JanitorMonkey {
 
     private final String region;
 
+    private final String accountName;
+
     private final JanitorResourceTracker resourceTracker;
 
     private final MonkeyRecorder recorder;
@@ -72,6 +74,7 @@ public class BasicJanitorMonkey extends JanitorMonkey {
         janitors = ctx.janitors();
         emailNotifier = ctx.emailNotifier();
         region = ctx.region();
+        accountName = ctx.accountName();
         resourceTracker = ctx.resourceTracker();
         recorder = ctx.recorder();
         calendar = ctx.calendar();
@@ -192,7 +195,7 @@ public class BasicJanitorMonkey extends JanitorMonkey {
      * @return the subject of the summary email
      */
     protected String getSummaryEmailSubject() {
-        return String.format("Janitor monkey execution summary (%s)", region);
+        return String.format("Janitor monkey execution summary (%s, %s)", accountName, region);
     }
 
     /**

--- a/src/main/java/com/netflix/simianarmy/client/aws/AWSClient.java
+++ b/src/main/java/com/netflix/simianarmy/client/aws/AWSClient.java
@@ -114,6 +114,9 @@ public class AWSClient implements CloudClient {
     /** The region. */
     private final String region;
 
+    /** The plain name for AWS account */
+    private final String accountName;
+
     private final AWSCredentialsProvider awsCredentialsProvider;
 
     private ComputeService jcloudsComputeService;
@@ -152,6 +155,7 @@ public class AWSClient implements CloudClient {
      */
     public AWSClient(String region) {
         this.region = region;
+        this.accountName = "Default";
         this.awsCredentialsProvider = null;
     }
 
@@ -164,6 +168,7 @@ public class AWSClient implements CloudClient {
      */
     public AWSClient(String region, AWSCredentialsProvider awsCredentialsProvider) {
         this.region = region;
+        this.accountName = "Default";
         this.awsCredentialsProvider = awsCredentialsProvider;
     }
 
@@ -174,6 +179,16 @@ public class AWSClient implements CloudClient {
      */
     public String region() {
         return region;
+    }
+
+    /**
+     * The accountName.
+     *
+     * @accountName the plain name for the aws account easier to identify which account
+     * monkey is running in
+     */
+    public String accountName() {
+        return accountName;
     }
 
     /**

--- a/src/main/java/com/netflix/simianarmy/janitor/JanitorMonkey.java
+++ b/src/main/java/com/netflix/simianarmy/janitor/JanitorMonkey.java
@@ -72,6 +72,12 @@ public abstract class JanitorMonkey extends Monkey {
         String region();
 
         /**
+         * The accountName the monkey is running in.
+         * @return the accountName the monkey is running in.
+         */
+        String accountName();
+
+        /**
          * The Janitor resource tracker.
          * @return the Janitor resource tracker.
          */

--- a/src/main/resources/client.properties
+++ b/src/main/resources/client.properties
@@ -26,6 +26,9 @@
 #simianarmy.client.aws.secretKey  = fakeSecret
 simianarmy.client.aws.region = us-west-1
 
+### Common account name to make it easier to identify emails by subject
+simianarmy.client.aws.accountName = default
+
 ### To operate under an assumed role - the role will be assumed for all activity, sts:AssumeRole 
 ### action must be allowed for the inital IAM role being used (long lived credentials)
 ### http://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html 

--- a/src/test/resources/client.properties
+++ b/src/test/resources/client.properties
@@ -1,3 +1,4 @@
 simianarmy.client.aws.accountKey = fakeAccount
 simianarmy.client.aws.secretKey  = fakeSecret
 simianarmy.client.aws.assumeRoleArn = arn:aws:iam::fakeAccount:role/fakeRole
+simianarmy.client.aws.accountName = default


### PR DESCRIPTION
Our issue was we were running multiple SimianArmy instances in multiple accounts, so we get multiple emails a day from Janitor Monkey and it was hard to determine which account the instances, ASG's, etc pertained to in each email. So we added an accountName variable that we could pass to each SimianArmy instance to help identify. This is a generic name that makes sense to the people familiar with the accounts in our case it is usually teamName_dev or prod.

So by setting src.main.resources.client.properties - <code>simianarmy.client.aws.accountName</code> you can see an account identifier in the Janitor Monkey emails, it will send default if not set.

We thought we'd post it back in case anyone else has a similar need.
Thanks
Danny