### PR TITLE
fixed SES client uses us-east-1 by default and SimpleDB cannot have dashes in name

### DIFF
--- a/src/main/java/com/netflix/simianarmy/aws/janitor/SimpleDBJanitorResourceTracker.java
+++ b/src/main/java/com/netflix/simianarmy/aws/janitor/SimpleDBJanitorResourceTracker.java
@@ -100,7 +100,7 @@ public class SimpleDBJanitorResourceTracker implements JanitorResourceTracker {
         Validate.notEmpty(resourceRegion);
         List<Resource> resources = new ArrayList<Resource>();
         StringBuilder query = new StringBuilder();
-        query.append(String.format("select * from %s where ", domain));
+        query.append(String.format("select * from `%s` where ", domain));
         if (resourceType != null) {
             query.append(String.format("resourceType='%s' and ", resourceType));
         }
@@ -130,7 +130,7 @@ public class SimpleDBJanitorResourceTracker implements JanitorResourceTracker {
     public Resource getResource(String resourceId) {
         Validate.notEmpty(resourceId);
         StringBuilder query = new StringBuilder();
-        query.append(String.format("select * from %s where resourceId = '%s'", domain, resourceId));
+        query.append(String.format("select * from `%s` where resourceId = '%s'", domain, resourceId));
 
         LOGGER.debug(String.format("Query is '%s'", query));
 

--- a/src/main/java/com/netflix/simianarmy/basic/BasicChaosMonkeyContext.java
+++ b/src/main/java/com/netflix/simianarmy/basic/BasicChaosMonkeyContext.java
@@ -18,6 +18,8 @@
 package com.netflix.simianarmy.basic;
 
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
 import com.netflix.simianarmy.MonkeyConfiguration;
 import com.netflix.simianarmy.basic.chaos.BasicChaosEmailNotifier;
 import com.netflix.simianarmy.basic.chaos.BasicChaosInstanceSelector;
@@ -51,7 +53,9 @@ public class BasicChaosMonkeyContext extends BasicSimianArmyContext implements C
         setChaosCrawler(new ASGChaosCrawler(awsClient()));
         setChaosInstanceSelector(new BasicChaosInstanceSelector());
         MonkeyConfiguration cfg = configuration();
-        setChaosEmailNotifier(new BasicChaosEmailNotifier(cfg, new AmazonSimpleEmailServiceClient(), null));
+	AmazonSimpleEmailServiceClient sesClient = new AmazonSimpleEmailServiceClient();
+        sesClient.setRegion(Region.getRegion(Regions.fromName(region())));
+        setChaosEmailNotifier(new BasicChaosEmailNotifier(cfg, sesClient, null));
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/com/netflix/simianarmy/basic/conformity/BasicConformityMonkeyContext.java
+++ b/src/main/java/com/netflix/simianarmy/basic/conformity/BasicConformityMonkeyContext.java
@@ -18,6 +18,8 @@
 package com.netflix.simianarmy.basic.conformity;
 
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.netflix.discovery.DiscoveryClient;
@@ -162,6 +164,7 @@ public class BasicConformityMonkeyContext extends BasicSimianArmyContext impleme
 
         clusterCrawler = new AWSClusterCrawler(regionToAwsClient, configuration());
         sesClient = new AmazonSimpleEmailServiceClient();
+	sesClient.setRegion(Region.getRegion(Regions.fromName(region())));
         defaultEmail = configuration().getStrOrElse("simianarmy.conformity.notification.defaultEmail", null);
         ccEmails = StringUtils.split(
                 configuration().getStrOrElse("simianarmy.conformity.notification.ccEmails", ""), ",");

--- a/src/main/java/com/netflix/simianarmy/basic/janitor/BasicJanitorMonkeyContext.java
+++ b/src/main/java/com/netflix/simianarmy/basic/janitor/BasicJanitorMonkeyContext.java
@@ -18,6 +18,8 @@
 package com.netflix.simianarmy.basic.janitor;
 
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
 import com.netflix.discovery.DiscoveryManager;
 import com.netflix.simianarmy.MonkeyCalendar;
 import com.netflix.simianarmy.MonkeyConfiguration;
@@ -120,6 +122,7 @@ public class BasicJanitorMonkeyContext extends BasicSimianArmyContext implements
 
         janitorEmailBuilder = new BasicJanitorEmailBuilder();
         sesClient = new AmazonSimpleEmailServiceClient();
+	sesClient.setRegion(Region.getRegion(Regions.fromName(region())));
         defaultEmail = configuration().getStrOrElse("simianarmy.janitor.notification.defaultEmail", "");
         ccEmails = StringUtils.split(
                 configuration().getStrOrElse("simianarmy.janitor.notification.ccEmails", ""), ",");


### PR DESCRIPTION
- Mails were rejected because it said that the email adress was not verified. Turned out that janitor monkey always sends emails via us-east-1
- I created an AWS SimpleDB instance with CloudFormation. It contained dashes in the domain name which broke janitor monkey