### PR TITLE
OpsWorks-aware Janitor monkey

### DIFF
--- a/src/main/java/com/netflix/simianarmy/aws/janitor/crawler/InstanceJanitorCrawler.java
+++ b/src/main/java/com/netflix/simianarmy/aws/janitor/crawler/InstanceJanitorCrawler.java
@@ -45,6 +45,9 @@ public class InstanceJanitorCrawler extends AbstractAWSJanitorCrawler {
     /** The name representing the additional field name of ASG's name. */
     public static final String INSTANCE_FIELD_ASG_NAME = "ASG_NAME";
 
+    /** The name representing the additional field name of the OpsWork stack name. */
+    public static final String  INSTANCE_FIELD_OPSWORKS_STACK_NAME = "OPSWORKS_STACK_NAME";
+
     /** The Constant LOGGER. */
     private static final Logger LOGGER = LoggerFactory.getLogger(InstanceJanitorCrawler.class);
 
@@ -101,6 +104,11 @@ public class InstanceJanitorCrawler extends AbstractAWSJanitorCrawler {
                 instanceResource.setAdditionalField(INSTANCE_FIELD_ASG_NAME, asgName);
                 LOGGER.info(String.format("instance %s has a ASG tag name %s.", instanceResource.getId(), asgName));
             }
+            String opsworksStackName = getOpsWorksStackName(instanceResource);
+            if (opsworksStackName != null) {
+                instanceResource.setAdditionalField(INSTANCE_FIELD_OPSWORKS_STACK_NAME, opsworksStackName);
+                LOGGER.info(String.format("instance %s is part of an OpsWorks stack named %s.", instanceResource.getId(), opsworksStackName));
+            }
             if (instance.getState() != null) {
                 ((AWSResource) instanceResource).setAWSResourceState(instance.getState().getName());
             }
@@ -121,5 +129,9 @@ public class InstanceJanitorCrawler extends AbstractAWSJanitorCrawler {
             }
         }
         return asgName;
+    }
+
+    private String getOpsWorksStackName(Resource instanceResource) {
+        return instanceResource.getTag("opsworks:stack");
     }
 }

--- a/src/main/java/com/netflix/simianarmy/basic/janitor/BasicJanitorMonkeyContext.java
+++ b/src/main/java/com/netflix/simianarmy/basic/janitor/BasicJanitorMonkeyContext.java
@@ -208,7 +208,10 @@ public class BasicJanitorMonkeyContext extends BasicSimianArmyContext implements
                                     "simianarmy.janitor.rule.orphanedInstanceRule.retentionDaysWithOwner", 3),
                                     (int) configuration().getNumOrElse(
                                             "simianarmy.janitor.rule.orphanedInstanceRule.retentionDaysWithoutOwner",
-                                            8)));
+                                            8),
+                                    configuration().getBoolOrElse(
+                                            "simianarmy.janitor.rule.orphanedInstanceRule.opsworks.parentage",
+                                            false)));
         }
         JanitorCrawler instanceCrawler;
         if (configuration().getBoolOrElse("simianarmy.janitor.edda.enabled", false)) {

--- a/src/main/resources/janitor.properties
+++ b/src/main/resources/janitor.properties
@@ -59,6 +59,8 @@ simianarmy.janitor.rule.orphanedInstanceRule.retentionDaysWithOwner = 3
 # The number of business days the instance is kept after a notification is sent for the termination
 # when the instance has no owner.
 simianarmy.janitor.rule.orphanedInstanceRule.retentionDaysWithoutOwner = 8
+# If true, don't consider members of an OpsWorks stack as orphans
+simianarmy.janitor.rule.orphanedInstanceRule.opsworks.parentage = false
 
 # The following properties are used by the Janitor rule for cleaning up volumes that have been
 # detached from instances for certain days.


### PR DESCRIPTION
Optionally consider membership in an OpsWorks stack when evaluating the orphaned instance rule for termination.  When this option is enabled, membership in an OpsWorks stack prevents deletion just like ASG membership.

ie.  OpsWorks loves you, little instance, you're not an orphan.