### PR TITLE
Email regex fix

### DIFF
--- a/src/main/java/com/netflix/simianarmy/aws/AWSEmailNotifier.java
+++ b/src/main/java/com/netflix/simianarmy/aws/AWSEmailNotifier.java
@@ -40,7 +40,7 @@ public abstract class AWSEmailNotifier implements MonkeyEmailNotifier {
     /** The Constant LOGGER. */
     private static final Logger LOGGER = LoggerFactory.getLogger(AWSEmailNotifier.class);
     private static final String EMAIL_PATTERN =
-            "^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@"
+            "^[_A-Za-z0-9-\\+\\.]+(.[_A-Za-z0-9-]+)*@"
                     + "[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$";
 
     private final Pattern emailPattern;

--- a/src/test/java/com/netflix/simianarmy/basic/chaos/TestBasicChaosEmailNotifier.java
+++ b/src/test/java/com/netflix/simianarmy/basic/chaos/TestBasicChaosEmailNotifier.java
@@ -68,6 +68,41 @@ public class TestBasicChaosEmailNotifier {
     }
 
     @Test
+    public void testInvalidEmailAddresses() {
+        String[] invalidEmails = new String[] { "username",
+                                                "username@.com.my",
+                                                "username123@example.a",
+                                                "username123@.com",
+                                                "username123@.com.com",
+                                                "username()*@example.com",
+                                                "username@%*.com"};
+        basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(properties), sesClient, null);
+
+        for (String emailAddress : invalidEmails) {
+            Assert.assertFalse(basicChaosEmailNotifier.isValidEmail(emailAddress));
+        }
+    }
+
+    @Test
+    public void testValidEmailAddresses() {
+        String[] validEmails = new String[] { "username-100@example.com",
+                                              "name.surname+ml-info@example.com",
+                                              "username.100@example.com",
+                                              "username111@example.com",
+                                              "username-100@username.net",
+                                              "username.100@example.com.au",
+                                              "username@1.com",
+                                              "username@example.com",
+                                              "username+100@example.com",
+                                              "username-100@example-test.com" };
+        basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(properties), sesClient, null);
+
+        for (String emailAddress : validEmails) {
+            Assert.assertTrue(basicChaosEmailNotifier.isValidEmail(emailAddress));
+        }
+    }
+
+    @Test
     public void testbuildEmailSubject() {
         basicChaosEmailNotifier = new BasicChaosEmailNotifier(new BasicConfiguration(properties), sesClient, null);
         String subject = basicChaosEmailNotifier.buildEmailSubject(to);


### PR DESCRIPTION
Email regex is wrong as it doesn't allow dots before the + symbol. e.g. name.surname+other@example.com
:cobertura
BUILD SUCCESSFUL
Total time: 46.275 secs