### PR TITLE
Override SES client region with an optional property and a SimpleDB fix

### DIFF
--- a/src/main/java/com/netflix/simianarmy/aws/janitor/SimpleDBJanitorResourceTracker.java
+++ b/src/main/java/com/netflix/simianarmy/aws/janitor/SimpleDBJanitorResourceTracker.java
@@ -100,7 +100,7 @@ public class SimpleDBJanitorResourceTracker implements JanitorResourceTracker {
         Validate.notEmpty(resourceRegion);
         List<Resource> resources = new ArrayList<Resource>();
         StringBuilder query = new StringBuilder();
-        query.append(String.format("select * from %s where ", domain));
+        query.append(String.format("select * from `%s` where ", domain));
         if (resourceType != null) {
             query.append(String.format("resourceType='%s' and ", resourceType));
         }
@@ -130,7 +130,7 @@ public class SimpleDBJanitorResourceTracker implements JanitorResourceTracker {
     public Resource getResource(String resourceId) {
         Validate.notEmpty(resourceId);
         StringBuilder query = new StringBuilder();
-        query.append(String.format("select * from %s where resourceId = '%s'", domain, resourceId));
+        query.append(String.format("select * from `%s` where resourceId = '%s'", domain, resourceId));
 
         LOGGER.debug(String.format("Query is '%s'", query));
 

--- a/src/main/java/com/netflix/simianarmy/basic/BasicChaosMonkeyContext.java
+++ b/src/main/java/com/netflix/simianarmy/basic/BasicChaosMonkeyContext.java
@@ -17,6 +17,9 @@
  */
 package com.netflix.simianarmy.basic;
 
+import com.amazonaws.regions.RegionUtils;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient;
 import com.netflix.simianarmy.MonkeyConfiguration;
 import com.netflix.simianarmy.basic.chaos.BasicChaosEmailNotifier;
@@ -51,7 +54,11 @@ public class BasicChaosMonkeyContext extends BasicSimianArmyContext implements C
         setChaosCrawler(new ASGChaosCrawler(awsClient()));
         setChaosInstanceSelector(new BasicChaosInstanceSelector());
         MonkeyConfiguration cfg = configuration();
-        setChaosEmailNotifier(new BasicChaosEmailNotifier(cfg, new AmazonSimpleEmailServiceClient(), null));
+        AmazonSimpleEmailServiceClient sesClient = new AmazonSimpleEmailServiceClient();
+        if (configuration().getStr("simianarmy.aws.email.region") != null) {
+           sesClient.setRegion(Region.getRegion(Regions.fromName(configuration().getStr("simianarmy.aws.email.region"))));
+        }
+        setChaosEmailNotifier(new BasicChaosEmailNotifier(cfg, sesClient, null));
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/com/netflix/simianarmy/basic/conformity/BasicConformityMonkeyContext.java
+++ b/src/main/java/com/netflix/simianarmy/basic/conformity/BasicConformityMonkeyContext.java
@@ -17,6 +17,8 @@
 // CHECKSTYLE IGNORE MagicNumberCheck
 package com.netflix.simianarmy.basic.conformity;
 
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -162,6 +164,9 @@ public class BasicConformityMonkeyContext extends BasicSimianArmyContext impleme
 
         clusterCrawler = new AWSClusterCrawler(regionToAwsClient, configuration());
         sesClient = new AmazonSimpleEmailServiceClient();
+        if (configuration().getStr("simianarmy.aws.email.region") != null) {
+          sesClient.setRegion(Region.getRegion(Regions.fromName(configuration().getStr("simianarmy.aws.email.region"))));
+        }        
         defaultEmail = configuration().getStrOrElse("simianarmy.conformity.notification.defaultEmail", null);
         ccEmails = StringUtils.split(
                 configuration().getStrOrElse("simianarmy.conformity.notification.ccEmails", ""), ",");

--- a/src/main/java/com/netflix/simianarmy/basic/janitor/BasicJanitorMonkeyContext.java
+++ b/src/main/java/com/netflix/simianarmy/basic/janitor/BasicJanitorMonkeyContext.java
@@ -17,6 +17,8 @@
 // CHECKSTYLE IGNORE MagicNumberCheck
 package com.netflix.simianarmy.basic.janitor;
 
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient;
 import com.netflix.discovery.DiscoveryManager;
 import com.netflix.simianarmy.MonkeyCalendar;
@@ -60,6 +62,7 @@ import com.netflix.simianarmy.janitor.JanitorEmailNotifier;
 import com.netflix.simianarmy.janitor.JanitorMonkey;
 import com.netflix.simianarmy.janitor.JanitorResourceTracker;
 import com.netflix.simianarmy.janitor.JanitorRuleEngine;
+
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -120,6 +123,9 @@ public class BasicJanitorMonkeyContext extends BasicSimianArmyContext implements
 
         janitorEmailBuilder = new BasicJanitorEmailBuilder();
         sesClient = new AmazonSimpleEmailServiceClient();
+        if (configuration().getStr("simianarmy.aws.email.region") != null) {
+           sesClient.setRegion(Region.getRegion(Regions.fromName(configuration().getStr("simianarmy.aws.email.region"))));
+        }
         defaultEmail = configuration().getStrOrElse("simianarmy.janitor.notification.defaultEmail", "");
         ccEmails = StringUtils.split(
                 configuration().getStrOrElse("simianarmy.janitor.notification.ccEmails", ""), ",");

--- a/src/main/resources/simianarmy.properties
+++ b/src/main/resources/simianarmy.properties
@@ -24,3 +24,6 @@ simianarmy.calendar.timezone = America/Los_Angeles
 # Allows you to Set the (case sensitive) AWS Tag Key to use for owner tags; e.g. Owner or owner
 # Will be Monkey Wide - used by all Monkeys. If not set defaults to "owner"
 # simianarmy.tags.owner = Owner
+
+# Region override for Amazon Simple Email Service Client
+#simianarmy.aws.email.region=us-west-1


### PR DESCRIPTION
Override SES client region with an optional property and a SimpleDB fix for dashes in names.

Addresses PR #177 and PR #142.