### PR TITLE
remove duplicate copyright notices

### DIFF
--- a/src/test/java/com/netflix/simianarmy/TestMonkey.java
+++ b/src/test/java/com/netflix/simianarmy/TestMonkey.java
@@ -16,23 +16,6 @@
  *
  */
 // CHECKSTYLE IGNORE Javadoc
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 package com.netflix.simianarmy;
 
 import org.testng.annotations.Test;

--- a/src/test/java/com/netflix/simianarmy/TestMonkeyRunner.java
+++ b/src/test/java/com/netflix/simianarmy/TestMonkeyRunner.java
@@ -16,23 +16,6 @@
  *
  */
 // CHECKSTYLE IGNORE Javadoc
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 package com.netflix.simianarmy;
 
 import java.util.List;

--- a/src/test/java/com/netflix/simianarmy/aws/TestSimpleDBRecorder.java
+++ b/src/test/java/com/netflix/simianarmy/aws/TestSimpleDBRecorder.java
@@ -16,23 +16,6 @@
  *
  */
 // CHECKSTYLE IGNORE Javadoc
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 package com.netflix.simianarmy.aws;
 
 import static org.mockito.Matchers.any;

--- a/src/test/java/com/netflix/simianarmy/aws/conformity/rule/TestInstanceInVPC.java
+++ b/src/test/java/com/netflix/simianarmy/aws/conformity/rule/TestInstanceInVPC.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2012 Netflix, Inc.
+ *  Copyright 2013 Netflix, Inc.
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -16,23 +16,6 @@
  *
  */
 // CHECKSTYLE IGNORE Javadoc
-/*
-*
-* Copyright 2013 Netflix, Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-*/
 package com.netflix.simianarmy.aws.conformity.rule;
 
 import com.amazonaws.services.ec2.model.Instance;

--- a/src/test/java/com/netflix/simianarmy/aws/janitor/TestAWSResource.java
+++ b/src/test/java/com/netflix/simianarmy/aws/janitor/TestAWSResource.java
@@ -17,23 +17,6 @@
  */
 // CHECKSTYLE IGNORE Javadoc
 // CHECKSTYLE IGNORE MagicNumberCheck
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 package com.netflix.simianarmy.aws.janitor;
 
 import java.lang.reflect.Field;

--- a/src/test/java/com/netflix/simianarmy/aws/janitor/TestSimpleDBJanitorResourceTracker.java
+++ b/src/test/java/com/netflix/simianarmy/aws/janitor/TestSimpleDBJanitorResourceTracker.java
@@ -18,23 +18,6 @@
 // CHECKSTYLE IGNORE Javadoc
 // CHECKSTYLE IGNORE MagicNumberCheck
 // CHECKSTYLE IGNORE ParameterNumber
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 package com.netflix.simianarmy.aws.janitor;
 
 import static org.mockito.Matchers.any;

--- a/src/test/java/com/netflix/simianarmy/aws/janitor/crawler/TestASGJanitorCrawler.java
+++ b/src/test/java/com/netflix/simianarmy/aws/janitor/crawler/TestASGJanitorCrawler.java
@@ -16,23 +16,6 @@
  *
  */
 // CHECKSTYLE IGNORE Javadoc
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 
 package com.netflix.simianarmy.aws.janitor.crawler;
 

--- a/src/test/java/com/netflix/simianarmy/aws/janitor/crawler/TestEBSSnapshotJanitorCrawler.java
+++ b/src/test/java/com/netflix/simianarmy/aws/janitor/crawler/TestEBSSnapshotJanitorCrawler.java
@@ -16,23 +16,6 @@
  *
  */
 //CHECKSTYLE IGNORE Javadoc
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 
 package com.netflix.simianarmy.aws.janitor.crawler;
 

--- a/src/test/java/com/netflix/simianarmy/aws/janitor/crawler/TestEBSVolumeJanitorCrawler.java
+++ b/src/test/java/com/netflix/simianarmy/aws/janitor/crawler/TestEBSVolumeJanitorCrawler.java
@@ -16,23 +16,6 @@
  *
  */
 //CHECKSTYLE IGNORE Javadoc
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 
 package com.netflix.simianarmy.aws.janitor.crawler;
 

--- a/src/test/java/com/netflix/simianarmy/aws/janitor/crawler/TestInstanceJanitorCrawler.java
+++ b/src/test/java/com/netflix/simianarmy/aws/janitor/crawler/TestInstanceJanitorCrawler.java
@@ -16,23 +16,6 @@
  *
  */
 // CHECKSTYLE IGNORE Javadoc
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 
 package com.netflix.simianarmy.aws.janitor.crawler;
 

--- a/src/test/java/com/netflix/simianarmy/aws/janitor/crawler/TestLaunchConfigJanitorCrawler.java
+++ b/src/test/java/com/netflix/simianarmy/aws/janitor/crawler/TestLaunchConfigJanitorCrawler.java
@@ -16,23 +16,6 @@
  *
  */
 // CHECKSTYLE IGNORE Javadoc
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 
 package com.netflix.simianarmy.aws.janitor.crawler;
 

--- a/src/test/java/com/netflix/simianarmy/aws/janitor/rule/TestMonkeyCalendar.java
+++ b/src/test/java/com/netflix/simianarmy/aws/janitor/rule/TestMonkeyCalendar.java
@@ -17,23 +17,6 @@
  */
 // CHECKSTYLE IGNORE Javadoc
 // CHECKSTYLE IGNORE MagicNumberCheck
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 package com.netflix.simianarmy.aws.janitor.rule;
 
 import java.util.Calendar;

--- a/src/test/java/com/netflix/simianarmy/aws/janitor/rule/asg/TestOldEmptyASGRule.java
+++ b/src/test/java/com/netflix/simianarmy/aws/janitor/rule/asg/TestOldEmptyASGRule.java
@@ -17,23 +17,6 @@
  */
 // CHECKSTYLE IGNORE Javadoc
 // CHECKSTYLE IGNORE MagicNumberCheck
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 
 package com.netflix.simianarmy.aws.janitor.rule.asg;
 

--- a/src/test/java/com/netflix/simianarmy/aws/janitor/rule/asg/TestSuspendedASGRule.java
+++ b/src/test/java/com/netflix/simianarmy/aws/janitor/rule/asg/TestSuspendedASGRule.java
@@ -17,23 +17,7 @@
  */
 //CHECKSTYLE IGNORE Javadoc
 //CHECKSTYLE IGNORE MagicNumberCheck
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
+
 
 package com.netflix.simianarmy.aws.janitor.rule.asg;
 

--- a/src/test/java/com/netflix/simianarmy/aws/janitor/rule/generic/TestUntaggedRule.java
+++ b/src/test/java/com/netflix/simianarmy/aws/janitor/rule/generic/TestUntaggedRule.java
@@ -17,23 +17,6 @@
  */
 // CHECKSTYLE IGNORE Javadoc
 // CHECKSTYLE IGNORE MagicNumberCheck
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 
 package com.netflix.simianarmy.aws.janitor.rule.generic;
 

--- a/src/test/java/com/netflix/simianarmy/aws/janitor/rule/instance/TestOrphanedInstanceRule.java
+++ b/src/test/java/com/netflix/simianarmy/aws/janitor/rule/instance/TestOrphanedInstanceRule.java
@@ -17,23 +17,6 @@
  */
 // CHECKSTYLE IGNORE Javadoc
 // CHECKSTYLE IGNORE MagicNumberCheck
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 
 package com.netflix.simianarmy.aws.janitor.rule.instance;
 

--- a/src/test/java/com/netflix/simianarmy/aws/janitor/rule/launchconfig/TestOldUnusedLaunchConfigRule.java
+++ b/src/test/java/com/netflix/simianarmy/aws/janitor/rule/launchconfig/TestOldUnusedLaunchConfigRule.java
@@ -17,23 +17,6 @@
  */
 // CHECKSTYLE IGNORE Javadoc
 // CHECKSTYLE IGNORE MagicNumberCheck
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 
 package com.netflix.simianarmy.aws.janitor.rule.launchconfig;
 

--- a/src/test/java/com/netflix/simianarmy/aws/janitor/rule/snapshot/TestNoGeneratedAMIRule.java
+++ b/src/test/java/com/netflix/simianarmy/aws/janitor/rule/snapshot/TestNoGeneratedAMIRule.java
@@ -17,23 +17,6 @@
  */
 //CHECKSTYLE IGNORE Javadoc
 //CHECKSTYLE IGNORE MagicNumberCheck
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 
 package com.netflix.simianarmy.aws.janitor.rule.snapshot;
 

--- a/src/test/java/com/netflix/simianarmy/aws/janitor/rule/volume/TestOldDetachedVolumeRule.java
+++ b/src/test/java/com/netflix/simianarmy/aws/janitor/rule/volume/TestOldDetachedVolumeRule.java
@@ -17,23 +17,6 @@
  */
 //CHECKSTYLE IGNORE Javadoc
 //CHECKSTYLE IGNORE MagicNumberCheck
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 
 package com.netflix.simianarmy.aws.janitor.rule.volume;
 

--- a/src/test/java/com/netflix/simianarmy/basic/TestBasicCalendar.java
+++ b/src/test/java/com/netflix/simianarmy/basic/TestBasicCalendar.java
@@ -16,23 +16,6 @@
  *
  */
 // CHECKSTYLE IGNORE Javadoc
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 package com.netflix.simianarmy.basic;
 
 import java.util.Calendar;

--- a/src/test/java/com/netflix/simianarmy/basic/TestBasicConfiguration.java
+++ b/src/test/java/com/netflix/simianarmy/basic/TestBasicConfiguration.java
@@ -16,23 +16,6 @@
  *
  */
 // CHECKSTYLE IGNORE Javadoc
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 package com.netflix.simianarmy.basic;
 
 import org.testng.annotations.Test;

--- a/src/test/java/com/netflix/simianarmy/basic/TestBasicContext.java
+++ b/src/test/java/com/netflix/simianarmy/basic/TestBasicContext.java
@@ -16,23 +16,6 @@
  *
  */
 // CHECKSTYLE IGNORE Javadoc
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 package com.netflix.simianarmy.basic;
 
 import org.testng.Assert;

--- a/src/test/java/com/netflix/simianarmy/basic/TestBasicMonkeyServer.java
+++ b/src/test/java/com/netflix/simianarmy/basic/TestBasicMonkeyServer.java
@@ -16,23 +16,6 @@
  *
  */
 // CHECKSTYLE IGNORE Javadoc
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 package com.netflix.simianarmy.basic;
 
 import org.testng.Assert;

--- a/src/test/java/com/netflix/simianarmy/basic/TestBasicRecorderEvent.java
+++ b/src/test/java/com/netflix/simianarmy/basic/TestBasicRecorderEvent.java
@@ -16,23 +16,6 @@
  *
  */
 // CHECKSTYLE IGNORE Javadoc
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 package com.netflix.simianarmy.basic;
 
 import java.util.HashMap;

--- a/src/test/java/com/netflix/simianarmy/basic/TestBasicScheduler.java
+++ b/src/test/java/com/netflix/simianarmy/basic/TestBasicScheduler.java
@@ -16,23 +16,6 @@
  *
  */
 // CHECKSTYLE IGNORE Javadoc
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 package com.netflix.simianarmy.basic;
 
 import static org.mockito.Mockito.when;

--- a/src/test/java/com/netflix/simianarmy/basic/chaos/TestBasicChaosEmailNotifier.java
+++ b/src/test/java/com/netflix/simianarmy/basic/chaos/TestBasicChaosEmailNotifier.java
@@ -1,23 +1,5 @@
 /*
  *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
-// CHECKSTYLE IGNORE Javadoc
-/*
- *
  *  Copyright 2013 Netflix, Inc.
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,6 +15,7 @@
  *     limitations under the License.
  *
  */
+// CHECKSTYLE IGNORE Javadoc
 package com.netflix.simianarmy.basic.chaos;
 
 import static org.mockito.Mockito.doNothing;

--- a/src/test/java/com/netflix/simianarmy/basic/chaos/TestBasicChaosInstanceSelector.java
+++ b/src/test/java/com/netflix/simianarmy/basic/chaos/TestBasicChaosInstanceSelector.java
@@ -16,23 +16,6 @@
  *
  */
 // CHECKSTYLE IGNORE Javadoc
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 package com.netflix.simianarmy.basic.chaos;
 
 import java.util.Collection;

--- a/src/test/java/com/netflix/simianarmy/basic/chaos/TestBasicChaosMonkey.java
+++ b/src/test/java/com/netflix/simianarmy/basic/chaos/TestBasicChaosMonkey.java
@@ -16,23 +16,6 @@
  *
  */
 // CHECKSTYLE IGNORE Javadoc
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 package com.netflix.simianarmy.basic.chaos;
 
 import java.util.List;

--- a/src/test/java/com/netflix/simianarmy/basic/chaos/TestCloudFormationChaosMonkey.java
+++ b/src/test/java/com/netflix/simianarmy/basic/chaos/TestCloudFormationChaosMonkey.java
@@ -16,23 +16,6 @@
  *
  */
 // CHECKSTYLE IGNORE Javadoc
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 package com.netflix.simianarmy.basic.chaos;
 
 import org.testng.Assert;

--- a/src/test/java/com/netflix/simianarmy/basic/janitor/TestBasicJanitorRuleEngine.java
+++ b/src/test/java/com/netflix/simianarmy/basic/janitor/TestBasicJanitorRuleEngine.java
@@ -17,23 +17,6 @@
  */
 // CHECKSTYLE IGNORE Javadoc
 // CHECKSTYLE IGNORE MagicNumberCheck
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 package com.netflix.simianarmy.basic.janitor;
 
 import java.util.Date;

--- a/src/test/java/com/netflix/simianarmy/chaos/TestChaosMonkeyArmy.java
+++ b/src/test/java/com/netflix/simianarmy/chaos/TestChaosMonkeyArmy.java
@@ -16,23 +16,6 @@
  *
  */
 // CHECKSTYLE IGNORE Javadoc
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 package com.netflix.simianarmy.chaos;
 
 import java.io.File;

--- a/src/test/java/com/netflix/simianarmy/chaos/TestChaosMonkeyContext.java
+++ b/src/test/java/com/netflix/simianarmy/chaos/TestChaosMonkeyContext.java
@@ -16,23 +16,6 @@
  *
  */
 // CHECKSTYLE IGNORE Javadoc
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 package com.netflix.simianarmy.chaos;
 
 import java.io.InputStream;

--- a/src/test/java/com/netflix/simianarmy/client/aws/TestAWSClient.java
+++ b/src/test/java/com/netflix/simianarmy/client/aws/TestAWSClient.java
@@ -16,23 +16,6 @@
  *
  */
 // CHECKSTYLE IGNORE Javadoc
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 package com.netflix.simianarmy.client.aws;
 
 import com.amazonaws.services.autoscaling.AmazonAutoScalingClient;

--- a/src/test/java/com/netflix/simianarmy/client/aws/chaos/TestASGChaosCrawler.java
+++ b/src/test/java/com/netflix/simianarmy/client/aws/chaos/TestASGChaosCrawler.java
@@ -16,23 +16,6 @@
  *
  */
 // CHECKSTYLE IGNORE Javadoc
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 package com.netflix.simianarmy.client.aws.chaos;
 
 import static org.mockito.Mockito.mock;

--- a/src/test/java/com/netflix/simianarmy/conformity/TestCrossZoneLoadBalancing.java
+++ b/src/test/java/com/netflix/simianarmy/conformity/TestCrossZoneLoadBalancing.java
@@ -1,23 +1,5 @@
 /*
  *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
-// CHECKSTYLE IGNORE Javadoc
-/*
- *
  *  Copyright 2013 Netflix, Inc.
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,6 +15,7 @@
  *     limitations under the License.
  *
  */
+// CHECKSTYLE IGNORE Javadoc
 package com.netflix.simianarmy.conformity;
 
 import java.util.Arrays;

--- a/src/test/java/com/netflix/simianarmy/conformity/TestSameZonesInElbAndAsg.java
+++ b/src/test/java/com/netflix/simianarmy/conformity/TestSameZonesInElbAndAsg.java
@@ -1,23 +1,5 @@
 /*
  *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
-// CHECKSTYLE IGNORE Javadoc
-/*
- *
  *  Copyright 2013 Netflix, Inc.
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,6 +15,7 @@
  *     limitations under the License.
  *
  */
+// CHECKSTYLE IGNORE Javadoc
 package com.netflix.simianarmy.conformity;
 
 import com.google.common.collect.Maps;

--- a/src/test/java/com/netflix/simianarmy/janitor/TestAbstractJanitor.java
+++ b/src/test/java/com/netflix/simianarmy/janitor/TestAbstractJanitor.java
@@ -17,23 +17,6 @@
  */
 // CHECKSTYLE IGNORE Javadoc
 // CHECKSTYLE IGNORE MagicNumberCheck
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 
 package com.netflix.simianarmy.janitor;
 

--- a/src/test/java/com/netflix/simianarmy/resources/chaos/TestChaosMonkeyResource.java
+++ b/src/test/java/com/netflix/simianarmy/resources/chaos/TestChaosMonkeyResource.java
@@ -17,23 +17,6 @@
  */
 // CHECKSTYLE IGNORE Javadoc
 //CHECKSTYLE IGNORE MagicNumber
-/*
- *
- *  Copyright 2012 Netflix, Inc.
- *
- *     Licensed under the Apache License, Version 2.0 (the "License");
- *     you may not use this file except in compliance with the License.
- *     You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
- */
 package com.netflix.simianarmy.resources.chaos;
 
 import static org.mockito.Matchers.any;


### PR DESCRIPTION
The "Missing header in:" messages from the licenseTest task were
erroneous - they were triggered because // CHECKSTYLE was the first line
in these test files. I'm hoping that the // CHECKSTYLE lines can occur after
the copyright?