### PR TITLE
fix for excludes in license tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'nebula.netflixoss' version '2.2.9'
     id 'net.saliman.cobertura' version '2.2.7'
+    id 'com.github.hierynomus.license' version '0.11.0'
 }
 
 // Establish version and status
@@ -62,8 +63,7 @@ tasks.withType(JavaCompile) {
 artifacts {
     archives tasks.jar
 }
-import nl.javadude.gradle.plugins.license.License
-tasks.withType(License).each { licenseTask ->
-    licenseTask.exclude '**/*.json'
-    licenseTask.exclude '**/*.properties'
+
+license {
+    excludes(["**/*.json", "**/*.properties", "**/*.sh"])
 }


### PR DESCRIPTION
I was getting "Missing header in:" for multiple

  *.properties
  *.json
  *.sh

before making this change