### PR TITLE
replace hardcoded "owner" with property

### DIFF
--- a/src/main/java/com/netflix/simianarmy/aws/janitor/crawler/edda/EddaEBSVolumeJanitorCrawler.java
+++ b/src/main/java/com/netflix/simianarmy/aws/janitor/crawler/edda/EddaEBSVolumeJanitorCrawler.java
@@ -96,9 +96,9 @@ public class EddaEBSVolumeJanitorCrawler implements JanitorCrawler {
         LOGGER.info(String.format("Getting owners for all instances in region %s", region));
 
         long startTime = DateTime.now().minusDays(LOOKBACK_DAYS).getMillis();
-        String url = String.format("%s/view/instances;_since=%d;state.name=running;tags.key=owner;"
+        String url = String.format("%1$s/view/instances;_since=%2$d;state.name=running;tags.key=%3$s;"
                 + "_expand:(instanceId,tags:(key,value))",
-                eddaClient.getBaseUrl(region), startTime);
+                eddaClient.getBaseUrl(region), startTime, BasicSimianArmyContext.GLOBAL_OWNER_TAGKEY);
         JsonNode jsonNode = null;
         try {
             jsonNode = eddaClient.getJsonNodeFromUrl(url);

--- a/src/main/java/com/netflix/simianarmy/aws/janitor/crawler/edda/EddaInstanceJanitorCrawler.java
+++ b/src/main/java/com/netflix/simianarmy/aws/janitor/crawler/edda/EddaInstanceJanitorCrawler.java
@@ -242,7 +242,7 @@ public class EddaInstanceJanitorCrawler implements JanitorCrawler {
             HashMap<String, String> imageToOwner = new HashMap<String, String>();
             String url = eddaClient.getBaseUrl(region) + "/aws/images/";
             url += StringUtils.join(imageIds, ',');
-            url += ";tags.key=owner;public=false;_expand:(imageId,tags:(owner))";
+            url += String.format(";tags.key=%1$s;public=false;_expand:(imageId,tags:(%1$s))", BasicSimianArmyContext.GLOBAL_OWNER_TAGKEY);
             JsonNode imageJsonNode = null;
             try {
                 imageJsonNode = eddaClient.getJsonNodeFromUrl(url);


### PR DESCRIPTION
use BasicSimianArmyContext.GLOBAL_OWNER_TAGKEY instead of hardcoded
owner

I was getting this error trying to run JanitorMonkey with Edda:

2015-10-09 14:58:00.991 -java.lang.RuntimeException: Failed to
get valid document from
http://localhost:8080/view/instances;_since=1436626680922;state.name=running;tags.key=owner;_expand:(instanceId,tags:(key,value)),
got: null

Even with janitor.properties containing:
simianarmy.janitor.edda.endpoint.us-east-1 = http://localhost:8080/api/v2

And with simianarmy.properties containing:
simianarmy.tags.owner = NotOwner