### PR TITLE
Change janitor metrics from counter to gauge.  Use resource arrays to…

### DIFF
--- a/src/test/java/com/netflix/simianarmy/janitor/TestAbstractJanitor.java
+++ b/src/test/java/com/netflix/simianarmy/janitor/TestAbstractJanitor.java
@@ -391,7 +391,7 @@ public class TestAbstractJanitor extends AbstractJanitor {
         janitor.markResources();
         Assert.assertEquals(janitor.getMarkedResources().size(), n / 2);
         Assert.assertEquals(janitor.getResourcesCleanedCount(), janitor.cleanedResourceIds.size());        
-        Assert.assertEquals(janitor.getMarkedResourcesCount(), janitor.markedResourceIds.size());
+        Assert.assertEquals(janitor.getMarkedResourcesCount(), n / 2);
 
         // No resource is really changed in tracker
         Assert.assertEquals(resourceTracker.getResources(


### PR DESCRIPTION
Change janitor metrics from counter to gauge.  Use resource arrays to track marks, cleans, etc. instead of using separate counter