### PR TITLE
Add a URL target to add events through HTTP GET; more Calendar logging

### DIFF
--- a/src/main/java/com/netflix/simianarmy/basic/BasicCalendar.java
+++ b/src/main/java/com/netflix/simianarmy/basic/BasicCalendar.java
@@ -24,6 +24,8 @@ import java.util.TimeZone;
 import java.util.TreeSet;
 
 import org.apache.commons.lang.Validate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.netflix.simianarmy.Monkey;
 import com.netflix.simianarmy.MonkeyCalendar;
@@ -34,6 +36,9 @@ import com.netflix.simianarmy.MonkeyConfiguration;
  * The Class BasicCalendar.
  */
 public class BasicCalendar implements MonkeyCalendar {
+
+    /** The Constant LOGGER. */
+    private static final Logger LOGGER = LoggerFactory.getLogger(BasicCalendar.class);
 
     /** The open hour. */
     private final int openHour;
@@ -78,6 +83,23 @@ public class BasicCalendar implements MonkeyCalendar {
         closeHour = close;
         tz = timezone;
     }
+    
+    /**
+     * Instantiates a new basic calendar.
+     *
+     * @param open
+     *            the open hour
+     * @param close
+     *            the close hour
+     * @param timezone
+     *            the timezone
+     */
+    public BasicCalendar(MonkeyConfiguration cfg, int open, int close, TimeZone timezone) {
+        this.cfg = cfg;
+        openHour = open;
+        closeHour = close;
+        tz = timezone;
+    }
 
     /** {@inheritDoc} */
     @Override
@@ -100,25 +122,32 @@ public class BasicCalendar implements MonkeyCalendar {
     /** {@inheritDoc} */
     @Override
     public boolean isMonkeyTime(Monkey monkey) {
-        if (cfg != null && cfg.getStrOrElse("simianarmy.calendar.isMonkeyTime", null) != null) {
-            return cfg.getBool("simianarmy.calendar.isMonkeyTime");
+        if (cfg != null && cfg.getStr("simianarmy.calendar.isMonkeyTime") != null) {
+        	boolean monkeyTime = cfg.getBool("simianarmy.calendar.isMonkeyTime");
+        	String msg = monkeyTime ? "Time for monkey." : "Not time for monkey.";
+        	LOGGER.debug("isMonkeyTime: Found property 'simianarmy.calendar.isMonkeyTime': " + monkeyTime + ". " + msg);
+            return monkeyTime;
         }
 
         Calendar now = now();
         int dow = now.get(Calendar.DAY_OF_WEEK);
         if (dow == Calendar.SATURDAY || dow == Calendar.SUNDAY) {
+        	LOGGER.debug("isMonkeyTime: Happy Weekend! Not time for monkey.");
             return false;
         }
 
         int hour = now.get(Calendar.HOUR_OF_DAY);
         if (hour < openHour || hour > closeHour) {
+        	LOGGER.debug("isMonkeyTime: Not inside open hours. Not time for monkey.");
             return false;
         }
 
         if (isHoliday(now)) {
+        	LOGGER.debug("isMonkeyTime: Happy Holiday! Not time for monkey.");
             return false;
         }
 
+    	LOGGER.debug("isMonkeyTime: Time for monkey.");
         return true;
     }
 

--- a/src/main/java/com/netflix/simianarmy/resources/janitor/JanitorMonkeyResource.java
+++ b/src/main/java/com/netflix/simianarmy/resources/janitor/JanitorMonkeyResource.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
@@ -71,6 +72,23 @@ public class JanitorMonkeyResource {
      */
     public JanitorMonkeyResource() {
         this.monkey = MonkeyRunner.getInstance().factory(JanitorMonkey.class);
+    }
+    
+    /**
+     * GET /api/v1/janitor/addEvent will try to a add a new event with the information in the url query string.
+     * This is the same as the regular POST addEvent except through a query string. This technically isn't
+     * very REST-ful as it is a GET call that creates an Opt-out/in event, but is a convenience method 
+     * for exposing opt-in/opt-out functionality more directly, for example in an email notification.
+     *
+     * @param eventType eventType from the query string
+     * @param resourceId resourceId from the query string
+     * @return the response
+     * @throws IOException
+     */
+    @GET @Path("addEvent")
+    public Response addEventThroughHttpGet( @QueryParam("eventType") String eventType,  @QueryParam("resourceId") String resourceId) throws IOException {
+    	String content = "{\"eventType\":\"" + eventType + "\",\"resourceId\":\"" + resourceId + "\"}";    	
+        return addEvent(content);        
     }
 
     /**


### PR DESCRIPTION
MonkeyCalendar: new constructor and better logging. Add a constructor to pass in configuration along with open/close/timezone. More logging in isMonkeyTime so it clearer why Monkey is taking time off.

JanitorMonkeyResource: Add URL target to allow adding events with a GET call, this is convenient for opt-in/opt-out through email.