### PR TITLE
BasicCalendar: isMonkeyTime=false should execute normally

### DIFF
--- a/src/main/java/com/netflix/simianarmy/basic/BasicCalendar.java
+++ b/src/main/java/com/netflix/simianarmy/basic/BasicCalendar.java
@@ -124,9 +124,12 @@ public class BasicCalendar implements MonkeyCalendar {
     public boolean isMonkeyTime(Monkey monkey) {
         if (cfg != null && cfg.getStr("simianarmy.calendar.isMonkeyTime") != null) {
         	boolean monkeyTime = cfg.getBool("simianarmy.calendar.isMonkeyTime");
-        	String msg = monkeyTime ? "Time for monkey." : "Not time for monkey.";
-        	LOGGER.debug("isMonkeyTime: Found property 'simianarmy.calendar.isMonkeyTime': " + monkeyTime + ". " + msg);
-            return monkeyTime;
+        	if (monkeyTime) {
+        		LOGGER.debug("isMonkeyTime: Found property 'simianarmy.calendar.isMonkeyTime': " + monkeyTime + ". Time for monkey.");
+        		return monkeyTime;
+        	} else {
+        		LOGGER.debug("isMonkeyTime: Found property 'simianarmy.calendar.isMonkeyTime': " + monkeyTime + ". Continuing regular calendar check for monkey time.");
+        	}
         }
 
         Calendar now = now();


### PR DESCRIPTION
BasicCalendar: When isMonkeyTime is false, monkeys should execute normal MonkeyCalendar logic to determine when they should run.  