### PR TITLE
NoGeneratedAMIRule: Add a property to override owner email

### DIFF
--- a/src/main/java/com/netflix/simianarmy/basic/janitor/BasicJanitorMonkeyContext.java
+++ b/src/main/java/com/netflix/simianarmy/basic/janitor/BasicJanitorMonkeyContext.java
@@ -293,7 +293,9 @@ public class BasicJanitorMonkeyContext extends BasicSimianArmyContext implements
             ruleEngine.addRule(new NoGeneratedAMIRule(monkeyCalendar,
                     (int) configuration().getNumOrElse("simianarmy.janitor.rule.noGeneratedAMIRule.ageThreshold", 30),
                     (int) configuration().getNumOrElse(
-                            "simianarmy.janitor.rule.noGeneratedAMIRule.retentionDays", 7)));
+                            "simianarmy.janitor.rule.noGeneratedAMIRule.retentionDays", 7),
+                    configuration().getStrOrElse(
+                            "simianarmy.janitor.rule.noGeneratedAMIRule.ownerEmail", null)));
         }
         if (configuration().getBoolOrElse("simianarmy.janitor.rule.untaggedRule.enabled", false)) {
             ruleEngine.addRule(new UntaggedRule(monkeyCalendar, getPropertySet("simianarmy.janitor.rule.untaggedRule.requiredTags"),


### PR DESCRIPTION
NoGeneratedAMIRule: Add a property to override owner email when cleaning EBS Snapshots.

This will enable notification emails to be sent to a different email target rather than the resource owner.  This could be useful for organizations that create a lot of snapshots as part of their build process and notifying owners is unnecessary.

The default value for this property is null meaning the resource owner will be notified and not the override value.