### PR TITLE
Adds proxy support to SES and some tests

### DIFF
--- a/src/main/java/com/netflix/simianarmy/basic/BasicChaosMonkeyContext.java
+++ b/src/main/java/com/netflix/simianarmy/basic/BasicChaosMonkeyContext.java
@@ -54,7 +54,7 @@ public class BasicChaosMonkeyContext extends BasicSimianArmyContext implements C
         setChaosCrawler(new ASGChaosCrawler(awsClient()));
         setChaosInstanceSelector(new BasicChaosInstanceSelector());
         MonkeyConfiguration cfg = configuration();
-        AmazonSimpleEmailServiceClient sesClient = new AmazonSimpleEmailServiceClient();
+        AmazonSimpleEmailServiceClient sesClient = new AmazonSimpleEmailServiceClient(awsClientConfig);
         if (configuration().getStr("simianarmy.aws.email.region") != null) {
            sesClient.setRegion(Region.getRegion(Regions.fromName(configuration().getStr("simianarmy.aws.email.region"))));
         }

--- a/src/main/java/com/netflix/simianarmy/basic/BasicSimianArmyContext.java
+++ b/src/main/java/com/netflix/simianarmy/basic/BasicSimianArmyContext.java
@@ -96,7 +96,7 @@ public class BasicSimianArmyContext implements Monkey.Context {
 
     private final String proxyPort;
 
-    private final String proxyUsernaem;
+    private final String proxyUsername;
 
     private final String proxyPassword;
 
@@ -132,13 +132,13 @@ public class BasicSimianArmyContext implements Monkey.Context {
         // Check for and configure optional proxy configuration
         proxyHost = config.getStr("simianarmy.client.aws.proxyHost");
         proxyPort = config.getStr("simianarmy.client.aws.proxyPort");
-        proxyUsernaem = config.getStr("simianarmy.client.aws.proxyUser");
+        proxyUsername = config.getStr("simianarmy.client.aws.proxyUser");
         proxyPassword = config.getStr("simianarmy.client.aws.proxyPassword");
         if ((proxyHost != null) && (proxyPort != null)) {
             awsClientConfig.setProxyHost(proxyHost);
             awsClientConfig.setProxyPort(Integer.parseInt(proxyPort));
-            if ((proxyUsernaem != null) && (proxyPassword != null)) {
-                awsClientConfig.setProxyUsername(proxyUsernaem);
+            if ((proxyUsername != null) && (proxyPassword != null)) {
+                awsClientConfig.setProxyUsername(proxyUsername);
                 awsClientConfig.setProxyPassword(proxyPassword);
             }
         }

--- a/src/main/java/com/netflix/simianarmy/basic/BasicSimianArmyContext.java
+++ b/src/main/java/com/netflix/simianarmy/basic/BasicSimianArmyContext.java
@@ -89,7 +89,7 @@ public class BasicSimianArmyContext implements Monkey.Context {
 
     private final String region;
 
-    private ClientConfiguration awsClientConfig = new ClientConfiguration();
+    protected ClientConfiguration awsClientConfig = new ClientConfiguration();
 
     /* If configured, the proxy to be used when making AWS API requests */
     private final String proxyHost;
@@ -390,6 +390,14 @@ public class BasicSimianArmyContext implements Monkey.Context {
      */
     public AWSCredentialsProvider getAwsCredentialsProvider() {
         return awsCredentialsProvider;
+    }
+
+    /**
+     * Gets the AWS client configuration.
+     * @return the AWS client configuration
+     */
+    public ClientConfiguration getAwsClientConfig() {
+        return awsClientConfig;
     }
 
     /**

--- a/src/test/java/com/netflix/simianarmy/basic/TestBasicContext.java
+++ b/src/test/java/com/netflix/simianarmy/basic/TestBasicContext.java
@@ -18,6 +18,8 @@
 // CHECKSTYLE IGNORE Javadoc
 package com.netflix.simianarmy.basic;
 
+import com.amazonaws.ClientConfiguration;
+
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -55,5 +57,29 @@ public class TestBasicContext {
     public void testIsNotSafeToLogVsphereProperty() {
         BasicChaosMonkeyContext ctx = new BasicChaosMonkeyContext();
         Assert.assertFalse(ctx.isSafeToLog("simianarmy.client.vsphere.password"));
+    }
+
+    @Test
+    public void testIsNotUsingProxyByDefault() {
+        BasicSimianArmyContext ctx = new BasicSimianArmyContext();
+
+        ClientConfiguration awsClientConfig = ctx.getAwsClientConfig();
+
+        Assert.assertNull(awsClientConfig.getProxyHost());
+        Assert.assertEquals(awsClientConfig.getProxyPort(), -1);
+        Assert.assertNull(awsClientConfig.getProxyUsername());
+        Assert.assertNull(awsClientConfig.getProxyPassword());
+    }
+
+    @Test
+    public void testIsAbleToUseProxyByConfiguration() {
+        BasicSimianArmyContext ctx = new BasicSimianArmyContext("proxy.properties");
+
+        ClientConfiguration awsClientConfig = ctx.getAwsClientConfig();
+
+        Assert.assertEquals(awsClientConfig.getProxyHost(), "192.168.0.0");
+        Assert.assertEquals(awsClientConfig.getProxyPort(), 80);
+        Assert.assertEquals(awsClientConfig.getProxyUsername(), "fakeUser");
+        Assert.assertEquals(awsClientConfig.getProxyPassword(), "fakePassword");
     }
 }

--- a/src/test/resources/proxy.properties
+++ b/src/test/resources/proxy.properties
@@ -1,0 +1,5 @@
+# Proxy configuration for the purpose of testing
+simianarmy.client.aws.proxyHost=192.168.0.0
+simianarmy.client.aws.proxyPort=80
+simianarmy.client.aws.proxyUser=fakeUser
+simianarmy.client.aws.proxyPassword=fakePassword


### PR DESCRIPTION
This merge should compliment this one: https://github.com/Netflix/SimianArmy/pull/196 which omitted support for SES that SimianArmy implements. Also added some test coverage on verifying the proxy configuration getting into the Basic Context.