### PR TITLE
Adding AWS region detection.

### DIFF
--- a/src/main/java/com/netflix/simianarmy/basic/BasicSimianArmyContext.java
+++ b/src/main/java/com/netflix/simianarmy/basic/BasicSimianArmyContext.java
@@ -31,6 +31,8 @@ import org.slf4j.LoggerFactory;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
 
 import com.netflix.simianarmy.CloudClient;
 import com.netflix.simianarmy.Monkey;
@@ -126,7 +128,15 @@ public class BasicSimianArmyContext implements Monkey.Context {
         account = config.getStr("simianarmy.client.aws.accountKey");
         secret = config.getStr("simianarmy.client.aws.secretKey");
         accountName = config.getStrOrElse("simianarmy.client.aws.accountName", "Default");
-        region = config.getStrOrElse("simianarmy.client.aws.region", "us-east-1");
+        
+        String defaultRegion = "us-east-1";
+        Region currentRegion = Regions.getCurrentRegion();
+        
+        if (currentRegion != null) {
+            defaultRegion = currentRegion.getName();
+        }
+        
+        region = config.getStrOrElse("simianarmy.client.aws.region", defaultRegion);
         GLOBAL_OWNER_TAGKEY = config.getStrOrElse("simianarmy.tags.owner", "owner");
 
         // Check for and configure optional proxy configuration

--- a/src/main/resources/client.properties
+++ b/src/main/resources/client.properties
@@ -24,6 +24,7 @@
 ### see: http://docs.aws.amazon.com/AWSSdkDocsJava/latest/DeveloperGuide/java-dg-roles.html
 #simianarmy.client.aws.accountKey = fakeAccount
 #simianarmy.client.aws.secretKey  = fakeSecret
+### Comment out the following line to detect the AWS region where the instance is running
 simianarmy.client.aws.region = us-west-1
 
 ### Common account name to make it easier to identify emails by subject


### PR DESCRIPTION
This PR adds the ability to remove the AWS region configuration from the properties file and instead detect and use the region where the SimianArmy is running.

Simply commenting out simianarmy.client.aws.region will enable detection.  Leaving the properties file as-is has no change.