### PR TITLE
Adding feature to specifiy resource types for untaggedResourceRule

### DIFF
--- a/src/main/java/com/netflix/simianarmy/basic/janitor/BasicJanitorMonkeyContext.java
+++ b/src/main/java/com/netflix/simianarmy/basic/janitor/BasicJanitorMonkeyContext.java
@@ -193,7 +193,8 @@ public class BasicJanitorMonkeyContext extends BasicSimianArmyContext implements
                                     instanceValidator
                     ));
         }
-        if (configuration().getBoolOrElse("simianarmy.janitor.rule.untaggedRule.enabled", false)) {
+        if (configuration().getBoolOrElse("simianarmy.janitor.rule.untaggedRule.enabled", false)
+            && getUntaggedRuleResourceSet().contains("ASG")) {
             ruleEngine.addRule(new UntaggedRule(monkeyCalendar, getPropertySet("simianarmy.janitor.rule.untaggedRule.requiredTags"),
                     (int) configuration().getNumOrElse(
                             "simianarmy.janitor.rule.untaggedRule.retentionDaysWithOwner", 3),
@@ -229,7 +230,8 @@ public class BasicJanitorMonkeyContext extends BasicSimianArmyContext implements
                                             "simianarmy.janitor.rule.orphanedInstanceRule.opsworks.parentage",
                                             false)));
         }
-        if (configuration().getBoolOrElse("simianarmy.janitor.rule.untaggedRule.enabled", false)) {
+        if (configuration().getBoolOrElse("simianarmy.janitor.rule.untaggedRule.enabled", false)
+            && getUntaggedRuleResourceSet().contains("INSTANCE")) {
             ruleEngine.addRule(new UntaggedRule(monkeyCalendar, getPropertySet("simianarmy.janitor.rule.untaggedRule.requiredTags"),
                     (int) configuration().getNumOrElse(
                             "simianarmy.janitor.rule.untaggedRule.retentionDaysWithOwner", 3),
@@ -265,7 +267,8 @@ public class BasicJanitorMonkeyContext extends BasicSimianArmyContext implements
                         "simianarmy.janitor.rule.deleteOnTerminationRule.retentionDays", 3)));
             }
         }
-        if (configuration().getBoolOrElse("simianarmy.janitor.rule.untaggedRule.enabled", false)) {
+        if (configuration().getBoolOrElse("simianarmy.janitor.rule.untaggedRule.enabled", false)
+            && getUntaggedRuleResourceSet().contains("EBS_VOLUME")) {
             ruleEngine.addRule(new UntaggedRule(monkeyCalendar, getPropertySet("simianarmy.janitor.rule.untaggedRule.requiredTags"),
                     (int) configuration().getNumOrElse(
                             "simianarmy.janitor.rule.untaggedRule.retentionDaysWithOwner", 3),
@@ -297,7 +300,8 @@ public class BasicJanitorMonkeyContext extends BasicSimianArmyContext implements
                     configuration().getStrOrElse(
                             "simianarmy.janitor.rule.noGeneratedAMIRule.ownerEmail", null)));
         }
-        if (configuration().getBoolOrElse("simianarmy.janitor.rule.untaggedRule.enabled", false)) {
+        if (configuration().getBoolOrElse("simianarmy.janitor.rule.untaggedRule.enabled", false)
+            && getUntaggedRuleResourceSet().contains("EBS_SNAPSHOT")) {
             ruleEngine.addRule(new UntaggedRule(monkeyCalendar, getPropertySet("simianarmy.janitor.rule.untaggedRule.requiredTags"),
                     (int) configuration().getNumOrElse(
                             "simianarmy.janitor.rule.untaggedRule.retentionDaysWithOwner", 3),
@@ -329,7 +333,8 @@ public class BasicJanitorMonkeyContext extends BasicSimianArmyContext implements
                     (int) configuration().getNumOrElse(
                             "simianarmy.janitor.rule.oldUnusedLaunchConfigRule.retentionDays", 3)));
         }
-        if (configuration().getBoolOrElse("simianarmy.janitor.rule.untaggedRule.enabled", false)) {
+        if (configuration().getBoolOrElse("simianarmy.janitor.rule.untaggedRule.enabled", false)
+            && getUntaggedRuleResourceSet().contains("LAUNCH_CONFIG")) {
             ruleEngine.addRule(new UntaggedRule(monkeyCalendar, getPropertySet("simianarmy.janitor.rule.untaggedRule.requiredTags"),
                     (int) configuration().getNumOrElse(
                             "simianarmy.janitor.rule.untaggedRule.retentionDaysWithOwner", 3),
@@ -370,7 +375,8 @@ public class BasicJanitorMonkeyContext extends BasicSimianArmyContext implements
                     (int) configuration().getNumOrElse(
                             "simianarmy.janitor.rule.unusedImageRule.lastReferenceDaysThreshold", 45)));
         }
-        if (configuration().getBoolOrElse("simianarmy.janitor.rule.untaggedRule.enabled", false)) {
+        if (configuration().getBoolOrElse("simianarmy.janitor.rule.untaggedRule.enabled", false)
+            && getUntaggedRuleResourceSet().contains("IMAGE")) {
             ruleEngine.addRule(new UntaggedRule(monkeyCalendar, getPropertySet("simianarmy.janitor.rule.untaggedRule.requiredTags"),
                     (int) configuration().getNumOrElse(
                             "simianarmy.janitor.rule.untaggedRule.retentionDaysWithOwner", 3),
@@ -401,6 +407,19 @@ public class BasicJanitorMonkeyContext extends BasicSimianArmyContext implements
             }
         }
         return enabledResourceSet;
+    }
+    
+    private Set<String> getUntaggedRuleResourceSet() {
+        Set<String> untaggedRuleResourceSet = new HashSet<String>();
+        if (configuration().getBoolOrElse("simianarmy.janitor.rule.untaggedRule.enabled", false)) {
+            String untaggedRuleResources = configuration().getStr("simianarmy.janitor.rule.untaggedRule.resources");
+            if (StringUtils.isNotBlank(untaggedRuleResources)) {
+                for (String resourceType : untaggedRuleResources.split(",")) {
+                    untaggedRuleResourceSet.add(resourceType.trim().toUpperCase());
+                }
+            }
+        }
+        return untaggedRuleResourceSet;
     }
 
     private Set<String> getPropertySet(String property) {

--- a/src/main/resources/janitor.properties
+++ b/src/main/resources/janitor.properties
@@ -67,6 +67,8 @@ simianarmy.janitor.rule.orphanedInstanceRule.opsworks.parentage = false
 simianarmy.janitor.rule.untaggedRule.enabled = false 
 # List of tags that are required for each resource
 simianarmy.janitor.rule.untaggedRule.requiredTags = owner, purpose, project
+# List of resource types that require tags
+simianarmy.janitor.rule.untaggedRule.resources = Instance, ASG, EBS_Volume, EBS_Snapshot, Launch_Config
 # The number of business days the resource is kept after a notification is sent for the deletion
 # when the resource has an owner.
 simianarmy.janitor.rule.untaggedRule.retentionDaysWithOwner = 2


### PR DESCRIPTION
Sometimes you don't care if specific resource types have tags (like Launch Configurations), but you want to require tags on other resource types (like Instances), yet you still want Janitor Monkey to track and clean-up all resources.

For example, EBS Volumes are attached after our deployment automation is finished and they therefore don't get a proper owner tag (even though Volume Tagging Monkey transfers the attached Instance owner tag to the meta-data EBS Volume tag). Additionally, Launch Configurations don't even support tags, so enabling the untaggedResourceRule seems to flag all Launch Configurations.

This feature allows one to opt-in only the resources they care about really having tags for the untaggedResourceRule.  If the resource type is not opted-in for Janitor Monkey at all that resource type will be ignored even if included in the untagged resource configuration.

