### PR TITLE
Apply the ASG Tag filtering on ASGCrawler

### DIFF
--- a/src/main/java/com/netflix/simianarmy/basic/chaos/BasicInstanceGroup.java
+++ b/src/main/java/com/netflix/simianarmy/basic/chaos/BasicInstanceGroup.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
+import com.amazonaws.services.autoscaling.model.TagDescription;
 import com.netflix.simianarmy.GroupType;
 import com.netflix.simianarmy.chaos.ChaosCrawler.InstanceGroup;
 
@@ -38,6 +39,9 @@ public class BasicInstanceGroup implements InstanceGroup {
     /** The region. */
     private final String region;
 
+    /** list of the tags of the ASG */
+    private final List<TagDescription> tags;
+
     /**
      * Instantiates a new basic instance group.
      *
@@ -45,12 +49,17 @@ public class BasicInstanceGroup implements InstanceGroup {
      *            the name
      * @param type
      *            the type
+     * @param tags
+     *            the ASG tags
      */
-    public BasicInstanceGroup(String name, GroupType type, String region) {
+    public BasicInstanceGroup(String name, GroupType type, String region, List<TagDescription> tags) {
         this.name = name;
         this.type = type;
         this.region = region;
+        this.tags = tags;
     }
+
+
 
     /** {@inheritDoc} */
     public GroupType type() {
@@ -65,6 +74,11 @@ public class BasicInstanceGroup implements InstanceGroup {
     /** {@inheritDoc} */
     public String region() {
         return region;
+    }
+
+    /** {@inheritDoc} */
+    public List<TagDescription> tags() {
+        return tags;
     }
 
     /** The list. */
@@ -85,7 +99,7 @@ public class BasicInstanceGroup implements InstanceGroup {
     /** {@inheritDoc} */
     @Override
     public BasicInstanceGroup copyAs(String newName) {
-        BasicInstanceGroup newGroup = new BasicInstanceGroup(newName, this.type(), this.region());
+        BasicInstanceGroup newGroup = new BasicInstanceGroup(newName, this.type(), this.region(), this.tags());
         for (String instance: this.instances()) {
             newGroup.addInstance(instance);
         }

--- a/src/main/java/com/netflix/simianarmy/chaos/ChaosCrawler.java
+++ b/src/main/java/com/netflix/simianarmy/chaos/ChaosCrawler.java
@@ -20,6 +20,7 @@ package com.netflix.simianarmy.chaos;
 import java.util.EnumSet;
 import java.util.List;
 
+import com.amazonaws.services.autoscaling.model.TagDescription;
 import com.netflix.simianarmy.GroupType;
 
 /**
@@ -52,6 +53,13 @@ public interface ChaosCrawler {
          * @return the region the group exists in
          */
         String region();
+
+        /**
+         * Tags.
+         *
+         * @return the list of tags associated with group type
+         */
+        List<TagDescription> tags();
 
         /**
          * Instances.

--- a/src/main/java/com/netflix/simianarmy/client/aws/chaos/ASGChaosCrawler.java
+++ b/src/main/java/com/netflix/simianarmy/client/aws/chaos/ASGChaosCrawler.java
@@ -108,9 +108,9 @@ public class ASGChaosCrawler implements ChaosCrawler {
 
       // if coefficient is 1 then the BasicInstanceGroup is fine, otherwise use Tunable
       if (aggressionCoefficient == 1.0) {
-          instanceGroup = new BasicInstanceGroup(asg.getAutoScalingGroupName(), Types.ASG, awsClient.region());
+          instanceGroup = new BasicInstanceGroup(asg.getAutoScalingGroupName(), Types.ASG, awsClient.region(), asg.getTags());
       } else {
-        TunableInstanceGroup tunable = new TunableInstanceGroup(asg.getAutoScalingGroupName(), Types.ASG, awsClient.region());
+        TunableInstanceGroup tunable = new TunableInstanceGroup(asg.getAutoScalingGroupName(), Types.ASG, awsClient.region(), asg.getTags());
         tunable.setAggressionCoefficient(aggressionCoefficient);
         
         instanceGroup = tunable;

--- a/src/main/java/com/netflix/simianarmy/client/aws/chaos/FilteringChaosCrawler.java
+++ b/src/main/java/com/netflix/simianarmy/client/aws/chaos/FilteringChaosCrawler.java
@@ -1,0 +1,68 @@
+/*
+ *
+ *  Copyright 2012 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.simianarmy.client.aws.chaos;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.netflix.simianarmy.chaos.ChaosCrawler;
+
+import java.util.EnumSet;
+import java.util.List;
+
+/**
+ * The Class FilteringChaosCrawler. This will filter the result from ASGChaosCrawler for all available AutoScalingGroups associated with the AWS account based on requested filter.
+ */
+public class FilteringChaosCrawler implements ChaosCrawler {
+
+    private final ChaosCrawler crawler;
+    private final Predicate<? super InstanceGroup> predicate;
+
+    public FilteringChaosCrawler(ChaosCrawler crawler, Predicate<? super InstanceGroup> predicate) {
+        this.crawler = crawler;
+        this.predicate = predicate;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public EnumSet<?> groupTypes() {
+        return crawler.groupTypes();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<InstanceGroup> groups() {
+        return filter(crawler.groups());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<InstanceGroup> groups(String... names) {
+        return filter(crawler.groups(names));
+    }
+
+
+    /**
+     * Return the filtered list of InstanceGroups using the requested predicate. The filter is applied on the InstanceGroup retrieved from the ASGChaosCrawler class.
+     * @param list list of InstanceGroups result of the chaos crawler
+     * @return The appropriate {@link InstanceGroup}
+     */
+    protected List<InstanceGroup> filter(List<InstanceGroup> list) {
+        return Lists.newArrayList(Iterables.filter(list, predicate));
+    }
+}

--- a/src/main/java/com/netflix/simianarmy/client/aws/chaos/TagPredicate.java
+++ b/src/main/java/com/netflix/simianarmy/client/aws/chaos/TagPredicate.java
@@ -1,0 +1,46 @@
+/*
+ *
+ *  Copyright 2012 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.simianarmy.client.aws.chaos;
+
+import com.amazonaws.services.autoscaling.model.TagDescription;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+import com.netflix.simianarmy.chaos.ChaosCrawler;
+
+/**
+ *  * The Class TagPredicate. This will apply the tag-key and the tag-value filter on the list of InstanceGroups .
+ */
+public class TagPredicate implements Predicate<ChaosCrawler.InstanceGroup> {
+
+    private final String key, value;
+
+    public TagPredicate(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    @Override
+    public boolean apply(ChaosCrawler.InstanceGroup instanceGroup) {
+        return Iterables.any(instanceGroup.tags(), new com.google.common.base.Predicate<TagDescription>() {
+            @Override
+            public boolean apply(TagDescription tagDescription) {
+                return tagDescription.getKey().equals(key) && tagDescription.getValue().equals(value);
+            }
+        });
+    }
+}

--- a/src/main/java/com/netflix/simianarmy/tunable/TunableInstanceGroup.java
+++ b/src/main/java/com/netflix/simianarmy/tunable/TunableInstanceGroup.java
@@ -1,7 +1,10 @@
 package com.netflix.simianarmy.tunable;
 
+import com.amazonaws.services.autoscaling.model.TagDescription;
 import com.netflix.simianarmy.GroupType;
 import com.netflix.simianarmy.basic.chaos.BasicInstanceGroup;
+
+import java.util.List;
 
 /**
  * Allows for individual InstanceGroups to alter the aggressiveness
@@ -12,8 +15,8 @@ import com.netflix.simianarmy.basic.chaos.BasicInstanceGroup;
  */
 public class TunableInstanceGroup extends BasicInstanceGroup {
   
-  public TunableInstanceGroup(String name, GroupType type, String region) {
-    super(name, type, region);
+  public TunableInstanceGroup(String name, GroupType type, String region, List<TagDescription> tags) {
+    super(name, type, region, tags);
   }
 
   private double aggressionCoefficient = 1.0;

--- a/src/main/resources/chaos.properties
+++ b/src/main/resources/chaos.properties
@@ -98,3 +98,6 @@ simianarmy.chaos.mandatoryTermination.defaultProbability = 0.5
 
 # Enable the email subject to be the same as the body, to include terminated instance and group information
 #simianarmy.chaos.notification.subject.isBody = true
+#set the tag filter on the ASGs to terminate only instances from the ASG with the this tag key and value
+#simianarmy.chaos.ASGtag.key = chaos_monkey
+#simianarmy.chaos.ASGtag.value = true

--- a/src/test/java/com/netflix/simianarmy/basic/chaos/TestBasicChaosInstanceSelector.java
+++ b/src/test/java/com/netflix/simianarmy/basic/chaos/TestBasicChaosInstanceSelector.java
@@ -18,12 +18,9 @@
 // CHECKSTYLE IGNORE Javadoc
 package com.netflix.simianarmy.basic.chaos;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Arrays;
-import java.util.Map;
-import java.util.HashMap;
+import java.util.*;
 
+import com.amazonaws.services.autoscaling.model.TagDescription;
 import com.netflix.simianarmy.GroupType;
 import com.netflix.simianarmy.chaos.ChaosInstanceSelector;
 import com.netflix.simianarmy.chaos.ChaosCrawler.InstanceGroup;
@@ -59,6 +56,10 @@ public class TestBasicChaosInstanceSelector {
 
         public String region() {
             return "region";
+        }
+
+        public List<TagDescription> tags() {
+            return Collections.<TagDescription>emptyList();
         }
 
         public List<String> instances() {

--- a/src/test/java/com/netflix/simianarmy/basic/chaos/TestBasicChaosMonkey.java
+++ b/src/test/java/com/netflix/simianarmy/basic/chaos/TestBasicChaosMonkey.java
@@ -18,6 +18,8 @@
 // CHECKSTYLE IGNORE Javadoc
 package com.netflix.simianarmy.basic.chaos;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -33,6 +35,7 @@ import com.netflix.simianarmy.chaos.ChaosCrawler.InstanceGroup;
 import com.netflix.simianarmy.chaos.ChaosMonkey;
 import com.netflix.simianarmy.chaos.TestChaosMonkeyContext;
 import com.netflix.simianarmy.resources.chaos.ChaosMonkeyResource;
+import com.amazonaws.services.autoscaling.model.TagDescription;
 
 // CHECKSTYLE IGNORE MagicNumberCheck
 public class TestBasicChaosMonkey {
@@ -360,17 +363,18 @@ public class TestBasicChaosMonkey {
 
     @Test
     public void testGetValueFromCfgWithDefault() {
+
         TestChaosMonkeyContext ctx = new TestChaosMonkeyContext("propertiesWithDefaults.properties");
         BasicChaosMonkey chaos = new BasicChaosMonkey(ctx);
 
         // named 1 has actual values in config
-        InstanceGroup named1 = new BasicInstanceGroup("named1", GroupTypes.TYPE_A, "test-dev-1");
+        InstanceGroup named1 = new BasicInstanceGroup("named1", GroupTypes.TYPE_A, "test-dev-1", Collections.<TagDescription>emptyList());
 
         // named 2 doesn't have values but it's group has values
-        InstanceGroup named2 = new BasicInstanceGroup("named2", GroupTypes.TYPE_A, "test-dev-1");
+        InstanceGroup named2 = new BasicInstanceGroup("named2", GroupTypes.TYPE_A, "test-dev-1", Collections.<TagDescription>emptyList());
 
         // named 3 doesn't have values and it's group doesn't have values
-        InstanceGroup named3 = new BasicInstanceGroup("named3", GroupTypes.TYPE_B, "test-dev-1");
+        InstanceGroup named3 = new BasicInstanceGroup("named3", GroupTypes.TYPE_B, "test-dev-1", Collections.<TagDescription>emptyList());
 
         Assert.assertEquals(chaos.getBoolFromCfgOrDefault(named1, "enabled", true), false);
         Assert.assertEquals(chaos.getNumFromCfgOrDefault(named1, "probability", 3.0), 1.1);

--- a/src/test/java/com/netflix/simianarmy/basic/chaos/TestCloudFormationChaosMonkey.java
+++ b/src/test/java/com/netflix/simianarmy/basic/chaos/TestCloudFormationChaosMonkey.java
@@ -18,6 +18,7 @@
 // CHECKSTYLE IGNORE Javadoc
 package com.netflix.simianarmy.basic.chaos;
 
+import com.amazonaws.services.autoscaling.model.TagDescription;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
@@ -26,6 +27,8 @@ import static org.testng.Assert.assertFalse;
 
 import com.netflix.simianarmy.chaos.TestChaosMonkeyContext;
 import com.netflix.simianarmy.chaos.ChaosCrawler.InstanceGroup;
+
+import java.util.Collections;
 
 public class TestCloudFormationChaosMonkey {
 
@@ -36,9 +39,9 @@ public class TestCloudFormationChaosMonkey {
         TestChaosMonkeyContext ctx = new TestChaosMonkeyContext("cloudformation.properties");
         CloudFormationChaosMonkey chaos = new CloudFormationChaosMonkey(ctx);
         InstanceGroup group1 = new BasicInstanceGroup("new-group-TestGroup1-XCFNFNFNF",
-                TestChaosMonkeyContext.CrawlerTypes.TYPE_D, "region");
+                TestChaosMonkeyContext.CrawlerTypes.TYPE_D, "region", Collections.<TagDescription>emptyList());
         InstanceGroup group2 = new BasicInstanceGroup("new-group-TestGroup2-XCFNGHFNF",
-                TestChaosMonkeyContext.CrawlerTypes.TYPE_D, "region");
+                TestChaosMonkeyContext.CrawlerTypes.TYPE_D, "region", Collections.<TagDescription>emptyList());
         assertTrue(chaos.isGroupEnabled(group1));
         assertFalse(chaos.isGroupEnabled(group2));
     }
@@ -48,7 +51,7 @@ public class TestCloudFormationChaosMonkey {
         TestChaosMonkeyContext ctx = new TestChaosMonkeyContext("cloudformation.properties");
         CloudFormationChaosMonkey chaos = new CloudFormationChaosMonkey(ctx);
         InstanceGroup group1 = new BasicInstanceGroup("new-group-TestGroup1-XCFNFNFNF",
-                TestChaosMonkeyContext.CrawlerTypes.TYPE_D, "region");
+                TestChaosMonkeyContext.CrawlerTypes.TYPE_D, "region", Collections.<TagDescription>emptyList());
         assertFalse(chaos.isMaxTerminationCountExceeded(group1));
     }
 
@@ -57,7 +60,7 @@ public class TestCloudFormationChaosMonkey {
         TestChaosMonkeyContext ctx = new TestChaosMonkeyContext("cloudformation.properties");
         CloudFormationChaosMonkey chaos = new CloudFormationChaosMonkey(ctx);
         InstanceGroup group1 = new BasicInstanceGroup("new-group-TestGroup1-XCFNFNFNF",
-                TestChaosMonkeyContext.CrawlerTypes.TYPE_D, "region");
+                TestChaosMonkeyContext.CrawlerTypes.TYPE_D, "region", Collections.<TagDescription>emptyList());
         assertEquals(1.0, chaos.getEffectiveProbability(group1));
     }
 
@@ -66,7 +69,7 @@ public class TestCloudFormationChaosMonkey {
         TestChaosMonkeyContext ctx = new TestChaosMonkeyContext("disabled.properties");
         CloudFormationChaosMonkey chaos = new CloudFormationChaosMonkey(ctx);
         InstanceGroup group = new BasicInstanceGroup("new-group-TestGroup-XCFNFNFNF",
-                TestChaosMonkeyContext.CrawlerTypes.TYPE_D, "region");
+                TestChaosMonkeyContext.CrawlerTypes.TYPE_D, "region", Collections.<TagDescription>emptyList());
         InstanceGroup newGroup = chaos.noSuffixInstanceGroup(group);
         assertEquals(newGroup.name(), "new-group-TestGroup");
     }
@@ -76,7 +79,7 @@ public class TestCloudFormationChaosMonkey {
         TestChaosMonkeyContext ctx = new TestChaosMonkeyContext("cloudformation.properties");
         CloudFormationChaosMonkey chaos = new CloudFormationChaosMonkey(ctx);
         InstanceGroup group = new BasicInstanceGroup("new-group-TestGroup1-XCFNFNFNF",
-                TestChaosMonkeyContext.CrawlerTypes.TYPE_D, "region");
+                TestChaosMonkeyContext.CrawlerTypes.TYPE_D, "region", Collections.<TagDescription>emptyList());
         assertEquals(chaos.getLastOptInMilliseconds(group), EXPECTED_MILLISECONDS);
     }
 

--- a/src/test/java/com/netflix/simianarmy/chaos/TestChaosMonkeyContext.java
+++ b/src/test/java/com/netflix/simianarmy/chaos/TestChaosMonkeyContext.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import com.amazonaws.services.autoscaling.model.TagDescription;
 import org.jclouds.compute.ComputeService;
 import org.jclouds.compute.domain.ExecChannel;
 import org.jclouds.compute.domain.ExecResponse;
@@ -89,6 +90,7 @@ public class TestChaosMonkeyContext extends TestMonkeyContext implements ChaosMo
         private final String name;
         private final String region;
         private final List<String> instances = new ArrayList<String>();
+        private final List<TagDescription> tags = new ArrayList<TagDescription>();
 
         public TestInstanceGroup(GroupType type, String name, String region, String... instances) {
             this.type = type;
@@ -97,6 +99,11 @@ public class TestChaosMonkeyContext extends TestMonkeyContext implements ChaosMo
             for (String i : instances) {
                 this.instances.add(i);
             }
+        }
+
+        @Override
+        public List<TagDescription> tags() {
+            return tags;
         }
 
         @Override

--- a/src/test/java/com/netflix/simianarmy/client/aws/chaos/TestFilterASGChaosCrawler.java
+++ b/src/test/java/com/netflix/simianarmy/client/aws/chaos/TestFilterASGChaosCrawler.java
@@ -1,0 +1,89 @@
+/*
+ *
+ *  Copyright 2012 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+// CHECKSTYLE IGNORE Javadoc
+package com.netflix.simianarmy.client.aws.chaos;
+
+
+import com.amazonaws.services.autoscaling.model.TagDescription;
+import com.netflix.simianarmy.GroupType;
+import com.netflix.simianarmy.basic.chaos.BasicInstanceGroup;
+import com.netflix.simianarmy.chaos.ChaosCrawler;
+import com.netflix.simianarmy.chaos.ChaosCrawler.InstanceGroup;
+
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+
+import java.util.*;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.assertEquals;
+
+public class TestFilterASGChaosCrawler {
+
+    private ChaosCrawler crawlerMock;
+    private ChaosCrawler crawler;
+    private String tagKey, tagValue;
+
+    public enum Types implements GroupType {
+
+        /** only crawls AutoScalingGroups. */
+        ASG;
+    }
+
+    @BeforeTest
+    public void beforeTest() {
+        crawlerMock = mock(ChaosCrawler.class);
+        tagKey = "key-" + UUID.randomUUID().toString();
+        tagValue = "tagValue-" + UUID.randomUUID().toString();
+        crawler = new FilteringChaosCrawler(crawlerMock, new TagPredicate(tagKey, tagValue));
+    }
+
+    @Test
+    public void testFilterGroups() {
+
+        List<TagDescription> tagList = new ArrayList<TagDescription>();
+        TagDescription td = new TagDescription();
+        td.setKey(tagKey);
+        td.setValue(tagValue);
+        tagList.add(td);
+
+        List<InstanceGroup> listGroup = new LinkedList<InstanceGroup>();
+        listGroup.add(new BasicInstanceGroup("asg1", Types.ASG, "region1", tagList) );
+        listGroup.add(new BasicInstanceGroup("asg2", Types.ASG, "region2", Collections.<TagDescription>emptyList()) );
+        listGroup.add(new BasicInstanceGroup("asg3", Types.ASG, "region3", tagList) );
+        listGroup.add(new BasicInstanceGroup("asg4", Types.ASG, "region4", Collections.<TagDescription>emptyList()) );
+
+        when(crawlerMock.groups()).thenReturn(listGroup);
+        List<InstanceGroup> groups = crawlerMock.groups();
+
+        assertEquals(groups.size(), 4);
+
+        groups = crawler.groups();
+
+
+
+        assertEquals(groups.size(), 2);
+
+        assertEquals(groups.get(0).name(), "asg1");
+
+        assertEquals(groups.get(1).name(), "asg3");
+    }
+
+
+}

--- a/src/test/java/com/netflix/simianarmy/tunable/TestTunablyAggressiveChaosMonkey.java
+++ b/src/test/java/com/netflix/simianarmy/tunable/TestTunablyAggressiveChaosMonkey.java
@@ -1,5 +1,6 @@
 package com.netflix.simianarmy.tunable;
 
+import com.amazonaws.services.autoscaling.model.TagDescription;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -7,6 +8,8 @@ import com.netflix.simianarmy.GroupType;
 import com.netflix.simianarmy.basic.chaos.BasicInstanceGroup;
 import com.netflix.simianarmy.chaos.ChaosCrawler.InstanceGroup;
 import com.netflix.simianarmy.chaos.TestChaosMonkeyContext;
+
+import java.util.Collections;
 
 public class TestTunablyAggressiveChaosMonkey {
   private enum GroupTypes implements GroupType {
@@ -19,7 +22,7 @@ public class TestTunablyAggressiveChaosMonkey {
 
     TunablyAggressiveChaosMonkey chaos = new TunablyAggressiveChaosMonkey(ctx);
 
-    InstanceGroup basic = new BasicInstanceGroup("basic", GroupTypes.TYPE_A, "region");
+    InstanceGroup basic = new BasicInstanceGroup("basic", GroupTypes.TYPE_A, "region", Collections.<TagDescription>emptyList());
     
     double probability = chaos.getEffectiveProbability(basic);
     
@@ -32,7 +35,7 @@ public class TestTunablyAggressiveChaosMonkey {
 
     TunablyAggressiveChaosMonkey chaos = new TunablyAggressiveChaosMonkey(ctx);
 
-    TunableInstanceGroup tuned = new TunableInstanceGroup("basic", GroupTypes.TYPE_A, "region");
+    TunableInstanceGroup tuned = new TunableInstanceGroup("basic", GroupTypes.TYPE_A, "region", Collections.<TagDescription>emptyList());
     tuned.setAggressionCoefficient(0.5);
     
     double probability = chaos.getEffectiveProbability(tuned);


### PR DESCRIPTION
The Chaos Monkey does not support the filtering based on ASG's tag. This is a PR for adding the tag filtering based on the key and value for Chaos Monkey. Each ASG with that tag (key, value) will be nominated for termination.