### PR TITLE
Email validation regex now accepts emails with hash in alias (before-…

### DIFF
--- a/src/main/java/com/netflix/simianarmy/aws/AWSEmailNotifier.java
+++ b/src/main/java/com/netflix/simianarmy/aws/AWSEmailNotifier.java
@@ -40,7 +40,7 @@ public abstract class AWSEmailNotifier implements MonkeyEmailNotifier {
     /** The Constant LOGGER. */
     private static final Logger LOGGER = LoggerFactory.getLogger(AWSEmailNotifier.class);
     private static final String EMAIL_PATTERN =
-            "^[_A-Za-z0-9-\\+\\.]+(.[_A-Za-z0-9-]+)*@"
+            "^[_A-Za-z0-9-\\+\\.#]+(.[_A-Za-z0-9-#]+)*@"
                     + "[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$";
 
     private final Pattern emailPattern;

--- a/src/test/java/com/netflix/simianarmy/aws/TestAWSEmailNotifier.java
+++ b/src/test/java/com/netflix/simianarmy/aws/TestAWSEmailNotifier.java
@@ -1,0 +1,32 @@
+package com.netflix.simianarmy.aws;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+// CHECKSTYLE IGNORE MagicNumberCheck
+public class TestAWSEmailNotifier extends AWSEmailNotifier {
+    public TestAWSEmailNotifier() {
+        super(null);
+    }
+
+    @Override
+    public String buildEmailSubject(String to) {
+        return null;
+    }
+
+    @Override
+    public String[] getCcAddresses(String to) {
+        return new String[0];
+    }
+
+    @Override
+    public String getSourceAddress(String to) {
+        return null;
+    }
+
+    @Test
+    public void testEmailWithHashIsValid() {
+        TestAWSEmailNotifier emailNotifier = new TestAWSEmailNotifier();
+        Assert.assertTrue(emailNotifier.isValidEmail("#bla-#name@domain-test.com"), "Email with hash is not valid");
+    }
+}


### PR DESCRIPTION
…@ part).

Fixes #250.