### PR TITLE
Redo: Adding feature to specify resource types for untaggedResource Rule

### DIFF
--- a/src/main/java/com/netflix/simianarmy/basic/janitor/BasicJanitorMonkeyContext.java
+++ b/src/main/java/com/netflix/simianarmy/basic/janitor/BasicJanitorMonkeyContext.java
@@ -197,7 +197,8 @@ public class BasicJanitorMonkeyContext extends BasicSimianArmyContext implements
                                     instanceValidator
                     ));
         }
-        if (configuration().getBoolOrElse("simianarmy.janitor.rule.untaggedRule.enabled", false)) {
+        if (configuration().getBoolOrElse("simianarmy.janitor.rule.untaggedRule.enabled", false)
+            && getUntaggedRuleResourceSet().contains("ASG")) {
             ruleEngine.addRule(new UntaggedRule(monkeyCalendar, getPropertySet("simianarmy.janitor.rule.untaggedRule.requiredTags"),
                     (int) configuration().getNumOrElse(
                             "simianarmy.janitor.rule.untaggedRule.retentionDaysWithOwner", 3),
@@ -233,7 +234,9 @@ public class BasicJanitorMonkeyContext extends BasicSimianArmyContext implements
                                             "simianarmy.janitor.rule.orphanedInstanceRule.opsworks.parentage",
                                             false)));
         }
-        if (configuration().getBoolOrElse("simianarmy.janitor.rule.untaggedRule.enabled", false)) {
+        
+        if (configuration().getBoolOrElse("simianarmy.janitor.rule.untaggedRule.enabled", false)
+            && getUntaggedRuleResourceSet().contains("INSTANCE")) {
             ruleEngine.addRule(new UntaggedRule(monkeyCalendar, getPropertySet("simianarmy.janitor.rule.untaggedRule.requiredTags"),
                     (int) configuration().getNumOrElse(
                             "simianarmy.janitor.rule.untaggedRule.retentionDaysWithOwner", 3),
@@ -269,7 +272,8 @@ public class BasicJanitorMonkeyContext extends BasicSimianArmyContext implements
                         "simianarmy.janitor.rule.deleteOnTerminationRule.retentionDays", 3)));
             }
         }
-        if (configuration().getBoolOrElse("simianarmy.janitor.rule.untaggedRule.enabled", false)) {
+        if (configuration().getBoolOrElse("simianarmy.janitor.rule.untaggedRule.enabled", false)
+            && getUntaggedRuleResourceSet().contains("EBS_VOLUME")) {
             ruleEngine.addRule(new UntaggedRule(monkeyCalendar, getPropertySet("simianarmy.janitor.rule.untaggedRule.requiredTags"),
                     (int) configuration().getNumOrElse(
                             "simianarmy.janitor.rule.untaggedRule.retentionDaysWithOwner", 3),
@@ -301,7 +305,8 @@ public class BasicJanitorMonkeyContext extends BasicSimianArmyContext implements
                     configuration().getStrOrElse(
                             "simianarmy.janitor.rule.noGeneratedAMIRule.ownerEmail", null)));
         }
-        if (configuration().getBoolOrElse("simianarmy.janitor.rule.untaggedRule.enabled", false)) {
+        if (configuration().getBoolOrElse("simianarmy.janitor.rule.untaggedRule.enabled", false)
+            && getUntaggedRuleResourceSet().contains("EBS_SNAPSHOT")) {
             ruleEngine.addRule(new UntaggedRule(monkeyCalendar, getPropertySet("simianarmy.janitor.rule.untaggedRule.requiredTags"),
                     (int) configuration().getNumOrElse(
                             "simianarmy.janitor.rule.untaggedRule.retentionDaysWithOwner", 3),
@@ -333,7 +338,8 @@ public class BasicJanitorMonkeyContext extends BasicSimianArmyContext implements
                     (int) configuration().getNumOrElse(
                             "simianarmy.janitor.rule.oldUnusedLaunchConfigRule.retentionDays", 3)));
         }
-        if (configuration().getBoolOrElse("simianarmy.janitor.rule.untaggedRule.enabled", false)) {
+        if (configuration().getBoolOrElse("simianarmy.janitor.rule.untaggedRule.enabled", false)
+            && getUntaggedRuleResourceSet().contains("LAUNCH_CONFIG")) {
             ruleEngine.addRule(new UntaggedRule(monkeyCalendar, getPropertySet("simianarmy.janitor.rule.untaggedRule.requiredTags"),
                     (int) configuration().getNumOrElse(
                             "simianarmy.janitor.rule.untaggedRule.retentionDaysWithOwner", 3),
@@ -374,7 +380,8 @@ public class BasicJanitorMonkeyContext extends BasicSimianArmyContext implements
                     (int) configuration().getNumOrElse(
                             "simianarmy.janitor.rule.unusedImageRule.lastReferenceDaysThreshold", 45)));
         }
-        if (configuration().getBoolOrElse("simianarmy.janitor.rule.untaggedRule.enabled", false)) {
+        if (configuration().getBoolOrElse("simianarmy.janitor.rule.untaggedRule.enabled", false)
+            && getUntaggedRuleResourceSet().contains("IMAGE")) {
             ruleEngine.addRule(new UntaggedRule(monkeyCalendar, getPropertySet("simianarmy.janitor.rule.untaggedRule.requiredTags"),
                     (int) configuration().getNumOrElse(
                             "simianarmy.janitor.rule.untaggedRule.retentionDaysWithOwner", 3),
@@ -407,6 +414,19 @@ public class BasicJanitorMonkeyContext extends BasicSimianArmyContext implements
         return enabledResourceSet;
     }
 
+    private Set<String> getUntaggedRuleResourceSet() {
+        Set<String> untaggedRuleResourceSet = new HashSet<String>();
+        if (configuration().getBoolOrElse("simianarmy.janitor.rule.untaggedRule.enabled", false)) {
+            String untaggedRuleResources = configuration().getStr("simianarmy.janitor.rule.untaggedRule.resources");
+            if (StringUtils.isNotBlank(untaggedRuleResources)) {
+                for (String resourceType : untaggedRuleResources.split(",")) {
+                    untaggedRuleResourceSet.add(resourceType.trim().toUpperCase());
+                }
+            }
+        }
+        return untaggedRuleResourceSet;
+    }
+ 
     private Set<String> getPropertySet(String property) {
         Set<String> propertyValueSet = new HashSet<String>();
         String propertyValue = configuration().getStr(property);

--- a/src/main/java/com/netflix/simianarmy/basic/janitor/BasicJanitorRuleEngine.java
+++ b/src/main/java/com/netflix/simianarmy/basic/janitor/BasicJanitorRuleEngine.java
@@ -98,4 +98,10 @@ public class BasicJanitorRuleEngine implements JanitorRuleEngine {
         rules.add(rule);
         return this;
     }
+    
+   /** {@inheritDoc} */
+    @Override
+    public List<Rule> getRules() {
+        return this.rules;
+    }
 }

--- a/src/main/java/com/netflix/simianarmy/janitor/JanitorRuleEngine.java
+++ b/src/main/java/com/netflix/simianarmy/janitor/JanitorRuleEngine.java
@@ -19,6 +19,7 @@
 package com.netflix.simianarmy.janitor;
 
 import com.netflix.simianarmy.Resource;
+import java.util.List;
 
 /**
  * The interface for janitor rule engine that can decide if a resource should be a candidate of cleanup
@@ -44,4 +45,11 @@ public interface JanitorRuleEngine {
      * @return The JanitorRuleEngine object.
      */
     JanitorRuleEngine addRule(Rule rule);
+    
+    /**
+     * Get rules to find out what's planned for enforcement.
+     *
+     * @return An ArrayList of Rules.
+     */
+    List<Rule> getRules();
 }

--- a/src/main/resources/janitor.properties
+++ b/src/main/resources/janitor.properties
@@ -67,6 +67,8 @@ simianarmy.janitor.rule.orphanedInstanceRule.opsworks.parentage = false
 simianarmy.janitor.rule.untaggedRule.enabled = false 
 # List of tags that are required for each resource
 simianarmy.janitor.rule.untaggedRule.requiredTags = owner, purpose, project
+# List of resource types that require tags
+simianarmy.janitor.rule.untaggedRule.resources = Instance, ASG, EBS_Volume, EBS_Snapshot
 # The number of business days the resource is kept after a notification is sent for the deletion
 # when the resource has an owner.
 simianarmy.janitor.rule.untaggedRule.retentionDaysWithOwner = 2

--- a/src/test/java/com/netflix/simianarmy/janitor/TestBasicJanitorMonkeyContext.java
+++ b/src/test/java/com/netflix/simianarmy/janitor/TestBasicJanitorMonkeyContext.java
@@ -1,0 +1,87 @@
+package com.netflix.simianarmy.basic.janitor;
+
+import com.netflix.simianarmy.aws.janitor.rule.generic.UntaggedRule;
+import com.netflix.simianarmy.basic.TestBasicCalendar;
+import com.netflix.simianarmy.janitor.JanitorRuleEngine;
+import com.netflix.simianarmy.janitor.Rule;
+
+import org.apache.commons.lang.StringUtils;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * The basic implementation of the context class for Janitor monkey.
+ */
+public class TestBasicJanitorMonkeyContext {
+    
+    private static final int SIMIANARMY_JANITOR_RULE_UNTAGGEDRULE_RETENTIONDAYSWITHOWNER = 3;
+    
+    private static final int SIMIANARMY_JANITOR_RULE_UNTAGGEDRULE_RETENTIONDAYSWITHOUTOWNER = 8;
+    
+    private static final Boolean SIMIANARMY_JANITOR_RULE_UNTAGGEDRULE_ENABLED = true;
+    
+    private static final Set<String> SIMIANARMY_JANITOR_RULE_UNTAGGEDRULE_REQUIREDTAGS = new HashSet<String>(Arrays.asList("owner", "costcenter"));
+    
+    private static final String SIMIANARMY_JANITOR_RULE_UNTAGGEDRULE_RESOURCES = "Instance";
+    
+    private String monkeyRegion;
+
+    private TestBasicCalendar monkeyCalendar;
+
+    public TestBasicJanitorMonkeyContext() {
+        super();
+    }
+    
+    @BeforeMethod
+    public void before() {
+        monkeyRegion = "us-east-1";
+        monkeyCalendar = new TestBasicCalendar();
+    }
+    
+    @Test
+    public void testAddRuleWithUntaggedRuleResource() {
+        JanitorRuleEngine ruleEngine = new BasicJanitorRuleEngine();
+        Boolean untaggedRuleEnabled = new Boolean(true);
+
+        Rule rule = new UntaggedRule(monkeyCalendar, SIMIANARMY_JANITOR_RULE_UNTAGGEDRULE_REQUIREDTAGS,
+                SIMIANARMY_JANITOR_RULE_UNTAGGEDRULE_RETENTIONDAYSWITHOWNER,
+                        SIMIANARMY_JANITOR_RULE_UNTAGGEDRULE_RETENTIONDAYSWITHOUTOWNER);
+        if (untaggedRuleEnabled && getUntaggedRuleResourceSet().contains("INSTANCE")) {
+            ruleEngine.addRule(rule);
+        }
+        Assert.assertTrue(ruleEngine.getRules().contains(rule));
+    }
+
+    @Test
+    public void testAddRuleWithoutUntaggedRuleResource() {
+        JanitorRuleEngine ruleEngine = new BasicJanitorRuleEngine();
+        Boolean untaggedRuleEnabled = new Boolean(true);
+
+        Rule rule = new UntaggedRule(monkeyCalendar, SIMIANARMY_JANITOR_RULE_UNTAGGEDRULE_REQUIREDTAGS,
+                SIMIANARMY_JANITOR_RULE_UNTAGGEDRULE_RETENTIONDAYSWITHOWNER,
+                        SIMIANARMY_JANITOR_RULE_UNTAGGEDRULE_RETENTIONDAYSWITHOUTOWNER);
+        if (untaggedRuleEnabled && getUntaggedRuleResourceSet().contains("ASG")) {
+            ruleEngine.addRule(rule);
+        }
+        Assert.assertFalse(ruleEngine.getRules().contains(rule));
+    }
+
+    private Set<String> getUntaggedRuleResourceSet() {
+        Set<String> untaggedRuleResourceSet = new HashSet<String>();
+        if (SIMIANARMY_JANITOR_RULE_UNTAGGEDRULE_ENABLED) {
+            String untaggedRuleResources = SIMIANARMY_JANITOR_RULE_UNTAGGEDRULE_RESOURCES;
+            if (StringUtils.isNotBlank(untaggedRuleResources)) {
+                for (String resourceType : untaggedRuleResources.split(",")) {
+                    untaggedRuleResourceSet.add(resourceType.trim().toUpperCase());
+                }
+            }
+        }
+        return untaggedRuleResourceSet;
+    }
+}


### PR DESCRIPTION
@ebukoski My last PR was old and so far behind master that I just reset and created this PR based on an up-to-date clone.  This PR has a couple of tests included.

Sometimes you don't care if specific resource types have tags (like Launch Configurations), but you want to require tags on other resource types (like Instances), yet you still want Janitor Monkey to track and clean-up all resources.

For example, EBS Volumes are attached after our deployment automation is finished and they therefore don't get a proper owner tag (even though Volume Tagging Monkey transfers the attached Instance owner tag to the meta-data EBS Volume tag). Additionally, Launch Configurations don't even support tags, so enabling the untaggedResourceRule seems to flag all Launch Configurations.

This feature allows one to opt-in only the resources they care about really having tags for the untaggedResourceRule. If the resource type is not opted-in for Janitor Monkey at all that resource type will be ignored even if included in the untagged resource configuration.