### PR TITLE
Make Conformity Monkey Notify Based on owner tag value

### DIFF
--- a/src/main/java/com/netflix/simianarmy/aws/conformity/crawler/AWSClusterCrawler.java
+++ b/src/main/java/com/netflix/simianarmy/aws/conformity/crawler/AWSClusterCrawler.java
@@ -111,7 +111,7 @@ public class AWSClusterCrawler implements ClusterCrawler {
                         }
                     }
                 }
-                
+
                 updateCluster(cluster);
                 list.add(cluster);
             }

--- a/src/main/java/com/netflix/simianarmy/aws/conformity/crawler/AWSClusterCrawler.java
+++ b/src/main/java/com/netflix/simianarmy/aws/conformity/crawler/AWSClusterCrawler.java
@@ -18,11 +18,13 @@
 package com.netflix.simianarmy.aws.conformity.crawler;
 
 import com.amazonaws.services.autoscaling.model.AutoScalingGroup;
+import com.amazonaws.services.autoscaling.model.TagDescription;
 import com.amazonaws.services.autoscaling.model.Instance;
 import com.amazonaws.services.autoscaling.model.SuspendedProcess;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.netflix.simianarmy.basic.BasicSimianArmyContext;
 import com.netflix.simianarmy.MonkeyConfiguration;
 import com.netflix.simianarmy.client.aws.AWSClient;
 import com.netflix.simianarmy.conformity.Cluster;
@@ -97,7 +99,19 @@ public class AWSClusterCrawler implements ClusterCrawler {
                         conformityAsg.setSuspended(true);
                     }
                 }
+
                 Cluster cluster = new Cluster(asg.getAutoScalingGroupName(), region, conformityAsg);
+                
+                List<TagDescription> tagDescriptions = asg.getTags();
+                for (TagDescription tagDescription : tagDescriptions) {
+                    if ( BasicSimianArmyContext.GLOBAL_OWNER_TAGKEY.equalsIgnoreCase(tagDescription.getKey()) ) {
+                        String value = tagDescription.getValue();
+                        if (value != null) {
+                            cluster.setOwnerEmail(value);
+                        }
+                    }
+                }
+                
                 updateCluster(cluster);
                 list.add(cluster);
             }
@@ -143,11 +157,18 @@ public class AWSClusterCrawler implements ClusterCrawler {
         String prop = String.format("%s.%s.ownerEmail", NS, cluster.getName());
         String ownerEmail = cfg.getStr(prop);
         if (ownerEmail == null) {
-            LOGGER.info(String.format("No owner email is found for cluster %s in configuration"
-                    + "please set property %s for it.", cluster.getName(), prop));
+            ownerEmail = cluster.getOwnerEmail();
+            if (ownerEmail == null) {
+                LOGGER.info(String.format("No owner email is found for cluster %s in configuration "
+                    + "%s or tag %s.", cluster.getName(), prop, BasicSimianArmyContext.GLOBAL_OWNER_TAGKEY));
+            } else {
+                LOGGER.info(String.format("Found owner email %s for cluster %s in tag %s.",
+                        ownerEmail, cluster.getName(), BasicSimianArmyContext.GLOBAL_OWNER_TAGKEY));
+                return ownerEmail;
+            }
         } else {
-            LOGGER.info(String.format("Found owner email %s for cluster %s in configuration.",
-                    ownerEmail, cluster.getName()));
+            LOGGER.info(String.format("Found owner email %s for cluster %s in configuration %s.",
+                    ownerEmail, cluster.getName(), prop));
         }
         return ownerEmail;
     }

--- a/src/test/java/com/netflix/simianarmy/aws/conformity/TestASGOwnerEmailTag.java
+++ b/src/test/java/com/netflix/simianarmy/aws/conformity/TestASGOwnerEmailTag.java
@@ -4,58 +4,51 @@ package com.netflix.simianarmy.aws.conformity;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.google.common.collect.Lists;
 import com.amazonaws.services.autoscaling.model.AutoScalingGroup;
+import com.amazonaws.services.autoscaling.model.SuspendedProcess;
 import com.amazonaws.services.autoscaling.model.TagDescription;
+
+import com.google.common.collect.Maps;
+
+import com.netflix.simianarmy.aws.conformity.crawler.AWSClusterCrawler;
+import com.netflix.simianarmy.basic.BasicConfiguration;
+import com.netflix.simianarmy.basic.conformity.BasicConformityMonkeyContext;
 import com.netflix.simianarmy.conformity.Cluster;
 import com.netflix.simianarmy.client.aws.AWSClient;
 
 import junit.framework.Assert;
 import org.testng.annotations.Test;
 
+import java.util.Map;
 import java.util.List;
 import java.util.LinkedList;
+import java.util.Properties;
 
 public class TestASGOwnerEmailTag {
+    
     private static final String ASG1 = "asg1";
     private static final String ASG2 = "asg2";
-    private static final String INSTANCE_ID = "i-01234567890";
     private static final String OWNER_TAG_KEY = "owner";
     private static final String OWNER_TAG_VALUE = "tyler@paperstreet.com";
     private static final String REGION = "eu-west-1";
 
     @Test
     public void testForOwnerTag() {
+        Properties properties = new Properties();
+        BasicConformityMonkeyContext ctx = new BasicConformityMonkeyContext();
+
         List<AutoScalingGroup> asgList = createASGList();
         String[] asgNames = {ASG1, ASG2};
+
         AWSClient awsMock = createMockAWSClient(asgList, asgNames);
-        List<Cluster> list = Lists.newArrayList();
-    
-        for (AutoScalingGroup asg : asgList) {
-            List<String> instances = Lists.newArrayList();
-            instances.add(INSTANCE_ID);
-            com.netflix.simianarmy.conformity.AutoScalingGroup conformityAsg =
-                    new com.netflix.simianarmy.conformity.AutoScalingGroup(
-                            asg.getAutoScalingGroupName(),
-                            instances.toArray(new String[instances.size()]));            
-            Cluster cluster = new Cluster(asg.getAutoScalingGroupName(), REGION, conformityAsg);
-            List<TagDescription> tagDescriptions = asg.getTags();
-            for (TagDescription tagDescription : tagDescriptions) {
-                if ( tagDescription.getKey() != null) {
-                    if ( OWNER_TAG_KEY.equalsIgnoreCase(tagDescription.getKey()) ) {
-                        String value = tagDescription.getValue();
-                        if (value != null) {
-                            cluster.setOwnerEmail(value);
-                        }
-                    }
-                }
-            }
-            list.add(cluster);
-        }
+        Map<String, AWSClient> regionToAwsClient = Maps.newHashMap();
+        regionToAwsClient.put("us-east-1", awsMock);
+        AWSClusterCrawler clusterCrawler = new AWSClusterCrawler(regionToAwsClient, new BasicConfiguration(properties));
+
+        List<Cluster> clusters = clusterCrawler.clusters(asgNames);
         
-        Assert.assertNotNull(list.get(0).getOwnerEmail());
-        Assert.assertTrue(list.get(0).getOwnerEmail().equalsIgnoreCase(OWNER_TAG_VALUE));
-        Assert.assertEquals(list.get(1).getOwnerEmail(), null);
+        Assert.assertTrue(OWNER_TAG_VALUE.equalsIgnoreCase(clusters.get(0).getOwnerEmail()));
+        Assert.assertNull(clusters.get(1).getOwnerEmail());
     }
 
     private List<AutoScalingGroup> createASGList() {
@@ -64,17 +57,18 @@ public class TestASGOwnerEmailTag {
         asgList.add(makeASG(ASG2, null));
         return asgList;
     }
+
+    private AutoScalingGroup makeASG(String asgName, String ownerEmail) {
+        TagDescription tag = new TagDescription().withKey(OWNER_TAG_KEY).withValue(ownerEmail);
+        AutoScalingGroup asg = new AutoScalingGroup()
+            .withAutoScalingGroupName(asgName)
+            .withTags(tag);
+        return asg;
+    }
     
     private AWSClient createMockAWSClient(List<AutoScalingGroup> asgList, String... asgNames) {
         AWSClient awsMock = mock(AWSClient.class);
         when(awsMock.describeAutoScalingGroups(asgNames)).thenReturn(asgList);
         return awsMock;
     }
-
-    private AutoScalingGroup makeASG(String asgName, String ownerEmail) {
-        TagDescription tag = new TagDescription().withKey(OWNER_TAG_KEY).withValue(ownerEmail);
-        AutoScalingGroup asg = new AutoScalingGroup().withAutoScalingGroupName(asgName).withTags(tag);
-        return asg;
-    }
-
 }

--- a/src/test/java/com/netflix/simianarmy/aws/conformity/TestASGOwnerEmailTag.java
+++ b/src/test/java/com/netflix/simianarmy/aws/conformity/TestASGOwnerEmailTag.java
@@ -1,0 +1,80 @@
+// CHECKSTYLE IGNORE Javadoc
+package com.netflix.simianarmy.aws.conformity;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.Lists;
+import com.amazonaws.services.autoscaling.model.AutoScalingGroup;
+import com.amazonaws.services.autoscaling.model.TagDescription;
+import com.netflix.simianarmy.conformity.Cluster;
+import com.netflix.simianarmy.client.aws.AWSClient;
+
+import junit.framework.Assert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.LinkedList;
+
+public class TestASGOwnerEmailTag {
+    private static final String ASG1 = "asg1";
+    private static final String ASG2 = "asg2";
+    private static final String INSTANCE_ID = "i-01234567890";
+    private static final String OWNER_TAG_KEY = "owner";
+    private static final String OWNER_TAG_VALUE = "tyler@paperstreet.com";
+    private static final String REGION = "eu-west-1";
+
+    @Test
+    public void testForOwnerTag() {
+        List<AutoScalingGroup> asgList = createASGList();
+        String[] asgNames = {ASG1, ASG2};
+        AWSClient awsMock = createMockAWSClient(asgList, asgNames);
+        List<Cluster> list = Lists.newArrayList();
+    
+        for (AutoScalingGroup asg : asgList) {
+            List<String> instances = Lists.newArrayList();
+            instances.add(INSTANCE_ID);
+            com.netflix.simianarmy.conformity.AutoScalingGroup conformityAsg =
+                    new com.netflix.simianarmy.conformity.AutoScalingGroup(
+                            asg.getAutoScalingGroupName(),
+                            instances.toArray(new String[instances.size()]));            
+            Cluster cluster = new Cluster(asg.getAutoScalingGroupName(), REGION, conformityAsg);
+            List<TagDescription> tagDescriptions = asg.getTags();
+            for (TagDescription tagDescription : tagDescriptions) {
+                if ( tagDescription.getKey() != null) {
+                    if ( OWNER_TAG_KEY.equalsIgnoreCase(tagDescription.getKey()) ) {
+                        String value = tagDescription.getValue();
+                        if (value != null) {
+                            cluster.setOwnerEmail(value);
+                        }
+                    }
+                }
+            }
+            list.add(cluster);
+        }
+        
+        Assert.assertNotNull(list.get(0).getOwnerEmail());
+        Assert.assertTrue(list.get(0).getOwnerEmail().equalsIgnoreCase(OWNER_TAG_VALUE));
+        Assert.assertEquals(list.get(1).getOwnerEmail(), null);
+    }
+
+    private List<AutoScalingGroup> createASGList() {
+        List<AutoScalingGroup> asgList = new LinkedList<AutoScalingGroup>();
+        asgList.add(makeASG(ASG1, OWNER_TAG_VALUE));
+        asgList.add(makeASG(ASG2, null));
+        return asgList;
+    }
+    
+    private AWSClient createMockAWSClient(List<AutoScalingGroup> asgList, String... asgNames) {
+        AWSClient awsMock = mock(AWSClient.class);
+        when(awsMock.describeAutoScalingGroups(asgNames)).thenReturn(asgList);
+        return awsMock;
+    }
+
+    private AutoScalingGroup makeASG(String asgName, String ownerEmail) {
+        TagDescription tag = new TagDescription().withKey(OWNER_TAG_KEY).withValue(ownerEmail);
+        AutoScalingGroup asg = new AutoScalingGroup().withAutoScalingGroupName(asgName).withTags(tag);
+        return asg;
+    }
+
+}


### PR DESCRIPTION
Conformity Monkey currently only notifies owner email addresses if they are listed in the properties files.

This change will enable notifications to the email address contained in the value of the GLOBAL_OWNER_TAGKEY when no owner is specified in the properties file. If the owner is specified in both, the properties file will take priority.