### PR TITLE
updating Resources to have application/json content-type

### DIFF
--- a/src/main/java/com/netflix/simianarmy/resources/chaos/ChaosMonkeyResource.java
+++ b/src/main/java/com/netflix/simianarmy/resources/chaos/ChaosMonkeyResource.java
@@ -28,7 +28,9 @@ import java.util.Map;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
@@ -58,6 +60,7 @@ import com.netflix.simianarmy.chaos.ShutdownInstanceChaosType;
  * The Class ChaosMonkeyResource for json REST apis.
  */
 @Path("/v1/chaos")
+@Produces(MediaType.APPLICATION_JSON)
 @Singleton
 public class ChaosMonkeyResource {
 

--- a/src/main/java/com/netflix/simianarmy/resources/janitor/JanitorMonkeyResource.java
+++ b/src/main/java/com/netflix/simianarmy/resources/janitor/JanitorMonkeyResource.java
@@ -24,8 +24,10 @@ import java.util.Map;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
@@ -46,6 +48,7 @@ import com.netflix.simianarmy.janitor.JanitorMonkey;
  * The Class JanitorMonkeyResource for json REST apis.
  */
 @Path("/v1/janitor")
+@Produces(MediaType.APPLICATION_JSON)
 public class JanitorMonkeyResource {
 
     /** The Constant JSON_FACTORY. */


### PR DESCRIPTION
Since this resource returns a JSON Array, let's set the Content-Type to the appropriate thing. Currently callers of this API are seeing a content-type of text/plain which technically is true, but for ease of integration and automated tools it should be set to reflect we are returning JSON in the body so "application/json" would be more accurate.

I also went beyond the original Issue #260 I created and am proposing to update the JanitorMonkeyResource in addition to the ChaosMonkeyResource.

Addresses Issue #260
