### PR TITLE
Add support for exclusion rules to JanitorRuleEngine

### DIFF
--- a/src/main/java/com/netflix/simianarmy/aws/janitor/crawler/edda/EddaImageJanitorCrawler.java
+++ b/src/main/java/com/netflix/simianarmy/aws/janitor/crawler/edda/EddaImageJanitorCrawler.java
@@ -74,7 +74,7 @@ public class EddaImageJanitorCrawler implements JanitorCrawler {
     private final Set<String> usedByInstance = Sets.newHashSet();
     private final Set<String> usedByLaunchConfig = Sets.newHashSet();
     private final Set<String> usedNames = Sets.newHashSet();
-    private final Map<String, String> imageIdToName = Maps.newHashMap();
+    protected final Map<String, String> imageIdToName = Maps.newHashMap();
     private final Map<String, Long> imageIdToCreationTime = Maps.newHashMap();
     private final Set<String> ancestorImageIds = Sets.newHashSet();
 

--- a/src/main/java/com/netflix/simianarmy/aws/janitor/rule/generic/TagValueExclusionRule.java
+++ b/src/main/java/com/netflix/simianarmy/aws/janitor/rule/generic/TagValueExclusionRule.java
@@ -1,0 +1,85 @@
+/*
+ *
+ *  Copyright 2012 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.simianarmy.aws.janitor.rule.generic;
+
+import com.netflix.simianarmy.Resource;
+import com.netflix.simianarmy.janitor.Rule;
+import org.apache.commons.lang.Validate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A rule for excluding resources that contain the provided tags (name and value).
+ *
+ * If a resource contains the tag and the appropriate value, it will be excluded from any
+ * other janitor rules and will not be cleaned.
+ *
+ */
+public class TagValueExclusionRule implements Rule {
+
+    /** The Constant LOGGER. */
+    private static final Logger LOGGER = LoggerFactory.getLogger(TagValueExclusionRule.class);
+    private final Map<String,String> tags;
+
+    /**
+     * Constructor for TagValueExclusionRule.
+     *
+     * @param tags
+     *            Set of tags and values to match for exclusion
+     */
+    public TagValueExclusionRule(Map<String, String> tags) {
+        this.tags = tags;
+    }
+
+    /**
+     * Constructor for TagValueExclusionRule.  Use this constructor to pass names and values as separate args.
+     * This is intended for convenience when specifying tag names/values in property files.
+     *
+     * Each tag[i] = (name[i], value[i])
+     *
+     * @param names
+     *            Set of names to match for exclusion.  Size of names must match size of values.
+     * @param values
+     *            Set of values to match for exclusion.  Size of names must match size of values.
+     */
+    public TagValueExclusionRule(String[] names, String[] values) {
+        tags = new HashMap<String,String>();
+        int i = 0;
+        for(String name : names) {
+            tags.put(name, values[i]);
+            i++;
+        }
+    }
+
+    @Override
+    public boolean isValid(Resource resource) {
+        Validate.notNull(resource);
+        for (String tagName : tags.keySet()) {
+            String resourceValue = resource.getTag(tagName);
+            if (resourceValue != null && resourceValue.equals(tags.get(tagName))) {
+                LOGGER.debug(String.format("The resource %s has the exclusion tag %s with value %s", resource.getId(), tagName, resourceValue));
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/netflix/simianarmy/janitor/JanitorRuleEngine.java
+++ b/src/main/java/com/netflix/simianarmy/janitor/JanitorRuleEngine.java
@@ -45,11 +45,29 @@ public interface JanitorRuleEngine {
      * @return The JanitorRuleEngine object.
      */
     JanitorRuleEngine addRule(Rule rule);
-    
+
+    /**
+     * Add a rule to decide if a resource should be excluded for cleanup.
+     * Exclusion rules are evaluated before regular rules.  If a resource
+     * matches an exclusion rule, it is excluded from all other cleanup rules.
+     *
+     * @param rule
+     *            The rule to decide if a resource should be excluded for cleanup.
+     * @return The JanitorRuleEngine object.
+     */
+    JanitorRuleEngine addExclusionRule(Rule rule);
+
     /**
      * Get rules to find out what's planned for enforcement.
      *
      * @return An ArrayList of Rules.
      */
     List<Rule> getRules();
+
+    /**
+     * Get rules to find out what's excluded for enforcement.
+     *
+     * @return An ArrayList of Rules.
+     */
+    List<Rule> getExclusionRules();
 }

--- a/src/test/java/com/netflix/simianarmy/aws/janitor/rule/generic/TestTagValueExclusionRule.java
+++ b/src/test/java/com/netflix/simianarmy/aws/janitor/rule/generic/TestTagValueExclusionRule.java
@@ -1,0 +1,138 @@
+/*
+ *
+ *  Copyright 2012 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+// CHECKSTYLE IGNORE Javadoc
+// CHECKSTYLE IGNORE MagicNumberCheck
+
+package com.netflix.simianarmy.aws.janitor.rule.generic;
+
+import com.netflix.simianarmy.Resource;
+import com.netflix.simianarmy.aws.AWSResource;
+import com.netflix.simianarmy.aws.AWSResourceType;
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+
+public class TestTagValueExclusionRule {
+
+    HashMap<String,String> exclusionTags = null;
+
+    @BeforeTest
+    public void beforeTest() {
+        exclusionTags = new HashMap<>();
+        exclusionTags.put("tag1", "excludeme");
+        exclusionTags.put("tag2", "excludeme2");
+    }
+
+    @Test
+    public void testExcludeTaggedResourceWithTagAndValueMatch1() {
+        Resource r1 = new AWSResource().withId("i-12345678901234567").withResourceType(AWSResourceType.INSTANCE).withOwnerEmail("owner@foo.com");
+        r1.setTag("tag", null);
+        r1.setTag("tag1", "excludeme");
+        r1.setTag("tag2", "somethingelse");
+
+        TagValueExclusionRule rule = new TagValueExclusionRule(exclusionTags);
+        Assert.assertTrue(rule.isValid(r1));
+    }
+
+    @Test
+    public void testExcludeTaggedResourceWithTagAndValueMatch2() {
+        Resource r1 = new AWSResource().withId("i-12345678901234567").withResourceType(AWSResourceType.INSTANCE).withOwnerEmail("owner@foo.com");
+        r1.setTag("tag", null);
+        r1.setTag("tag1", "somethingelse");
+        r1.setTag("tag2", "excludeme2");
+
+        TagValueExclusionRule rule = new TagValueExclusionRule(exclusionTags);
+        Assert.assertTrue(rule.isValid(r1));
+    }
+
+    @Test
+    public void testExcludeTaggedResourceWithTagAndValueMatchBoth() {
+        Resource r1 = new AWSResource().withId("i-12345678901234567").withResourceType(AWSResourceType.INSTANCE).withOwnerEmail("owner@foo.com");
+        r1.setTag("tag", null);
+        r1.setTag("tag1", "excludeme");
+        r1.setTag("tag2", "excludeme2");
+
+        TagValueExclusionRule rule = new TagValueExclusionRule(exclusionTags);
+        Assert.assertTrue(rule.isValid(r1));
+    }
+
+    @Test
+    public void testExcludeTaggedResourceTagMatchOnly() {
+        Resource r1 = new AWSResource().withId("i-12345678901234567").withResourceType(AWSResourceType.INSTANCE).withOwnerEmail("owner@foo.com");
+        r1.setTag("tag", null);
+        r1.setTag("tag1", "somethingelse");
+        r1.setTag("tag2", "somethingelse2");
+
+        TagValueExclusionRule rule = new TagValueExclusionRule(exclusionTags);
+        Assert.assertFalse(rule.isValid(r1));
+    }
+
+    @Test
+    public void testExcludeTaggedResourceAllNullTags() {
+        Resource r1 = new AWSResource().withId("i-12345678901234567").withResourceType(AWSResourceType.INSTANCE).withOwnerEmail("owner@foo.com");
+        r1.setTag("tag", null);
+        r1.setTag("tag1", null);
+        r1.setTag("tag2", null);
+
+        TagValueExclusionRule rule = new TagValueExclusionRule(exclusionTags);
+        Assert.assertFalse(rule.isValid(r1));
+    }
+
+    @Test
+    public void testExcludeTaggedResourceValueMatchOnly() {
+        Resource r1 = new AWSResource().withId("i-12345678901234567").withResourceType(AWSResourceType.INSTANCE).withOwnerEmail("owner@foo.com");
+        r1.setTag("tag", null);
+        r1.setTag("tagA", "excludeme");
+        r1.setTag("tagB", "excludeme2");
+
+        TagValueExclusionRule rule = new TagValueExclusionRule(exclusionTags);
+        Assert.assertFalse(rule.isValid(r1));
+    }
+
+    @Test
+    public void testExcludeUntaggedResource() {
+        Resource r1 = new AWSResource().withId("i-12345678901234567").withResourceType(AWSResourceType.INSTANCE).withOwnerEmail("owner@foo.com");
+
+        TagValueExclusionRule rule = new TagValueExclusionRule(exclusionTags);
+        Assert.assertFalse(rule.isValid(r1));
+    }
+
+    @Test
+    public void testNameValueConstructor() {
+        Resource r1 = new AWSResource().withId("i-12345678901234567").withResourceType(AWSResourceType.INSTANCE).withOwnerEmail("owner@foo.com");
+        r1.setTag("tag1", "excludeme");
+
+        String names = "tag1";
+        String vals  = "excludeme";
+        TagValueExclusionRule rule = new TagValueExclusionRule(names.split(","), vals.split(","));
+        Assert.assertTrue(rule.isValid(r1));
+    }
+
+    @Test
+    public void testNameValueConstructor2() {
+        Resource r1 = new AWSResource().withId("i-12345678901234567").withResourceType(AWSResourceType.INSTANCE).withOwnerEmail("owner@foo.com");
+        r1.setTag("tag1", "excludeme");
+
+        String names = "tag1,tag2";
+        String vals  = "excludeme,excludeme2";
+        TagValueExclusionRule rule = new TagValueExclusionRule(names.split(","), vals.split(","));
+        Assert.assertTrue(rule.isValid(r1));
+    }
+}

--- a/src/test/java/com/netflix/simianarmy/basic/janitor/TestBasicJanitorRuleEngine.java
+++ b/src/test/java/com/netflix/simianarmy/basic/janitor/TestBasicJanitorRuleEngine.java
@@ -19,15 +19,14 @@
 // CHECKSTYLE IGNORE MagicNumberCheck
 package com.netflix.simianarmy.basic.janitor;
 
-import java.util.Date;
-
+import com.netflix.simianarmy.Resource;
+import com.netflix.simianarmy.aws.AWSResource;
+import com.netflix.simianarmy.janitor.Rule;
 import org.joda.time.DateTime;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.netflix.simianarmy.Resource;
-import com.netflix.simianarmy.aws.AWSResource;
-import com.netflix.simianarmy.janitor.Rule;
+import java.util.Date;
 
 public class TestBasicJanitorRuleEngine {
 
@@ -78,6 +77,41 @@ public class TestBasicJanitorRuleEngine {
         }
     }
 
+    @Test void testWithExclusionRuleMatch1() {
+        Resource resource = new AWSResource().withId("id");
+        DateTime now = DateTime.now();
+        BasicJanitorRuleEngine engine = new BasicJanitorRuleEngine()
+                .addExclusionRule(new AlwaysValidRule())
+                .addRule(new AlwaysInvalidRule(now, 1));
+        Assert.assertTrue(engine.isValid(resource));
+    }
+
+    @Test void testWithExclusionRuleMatch2() {
+        Resource resource = new AWSResource().withId("id");
+        DateTime now = DateTime.now();
+        BasicJanitorRuleEngine engine = new BasicJanitorRuleEngine()
+                .addExclusionRule(new AlwaysValidRule())
+                .addRule(new AlwaysValidRule());
+        Assert.assertTrue(engine.isValid(resource));
+    }
+
+    @Test void testWithExclusionRuleNotMatch1() {
+        Resource resource = new AWSResource().withId("id");
+        DateTime now = DateTime.now();
+        BasicJanitorRuleEngine engine = new BasicJanitorRuleEngine()
+                .addExclusionRule(new AlwaysInvalidRule(now, 1))
+                .addRule(new AlwaysInvalidRule(now, 1));
+        Assert.assertFalse(engine.isValid(resource));
+    }
+
+    @Test void testWithExclusionRuleNotMatch2() {
+        Resource resource = new AWSResource().withId("id");
+        DateTime now = DateTime.now();
+        BasicJanitorRuleEngine engine = new BasicJanitorRuleEngine()
+                .addExclusionRule(new AlwaysInvalidRule(now, 1))
+                .addRule(new AlwaysValidRule());
+        Assert.assertTrue(engine.isValid(resource));
+    }
 }
 
 class AlwaysValidRule implements Rule {


### PR DESCRIPTION
An exclusion rule is a Rule that when matched, causes the resource to be excluded from being matched against any other cleanup rules.  It enables a resource to be "Opted Out" of cleanup.

A TagValueExclusionRule is included in this PR which excludes any resource that has a specified tag and value.

TagValueExclusionRule is disabled by default and is enabled by setting the following property:

```
simianarmy.janitor.rule.TagValueExclusionRule.enabled=true
```

The TagValueExclusionRule is configured with two properties:

```
simianarmy.janitor.rule.TagValueExclusionRule.tags=
simianarmy.janitor.rule.TagValueExclusionRule.values=
```

The first property specifies the tags that invoke the exclusion rules and he second property specifies the values.  For example, to exclude any resource tagged with "expiration_time=never" use this configuration:

```
simianarmy.janitor.rule.TagValueExclusionRule.enabled=true
simianarmy.janitor.rule.TagValueExclusionRule.tags=expiration_time
simianarmy.janitor.rule.TagValueExclusionRule.values=never
```

Another example: to exclude any resource tagged with "expiration_time=never" or "optout=true" use this configuration

```
simianarmy.janitor.rule.TagValueExclusionRule.enabled=true
simianarmy.janitor.rule.TagValueExclusionRule.tags=expiration_time,optout
simianarmy.janitor.rule.TagValueExclusionRule.values=never,true
```