### PR TITLE
Changes for Netflix environment compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     compile 'org.codehaus.jackson:jackson-core-asl:1.9.2'
     compile 'org.codehaus.jackson:jackson-mapper-asl:1.9.2'
     compile 'com.netflix.eureka:eureka-client:1.4.1'
-    compile 'com.amazonaws:aws-java-sdk:1.10.5.1'
+    compile 'com.amazonaws:aws-java-sdk:1.11.9'
     compile 'commons-lang:commons-lang:2.6'
     compile 'com.google.guava:guava:11.0.2'
     compile 'org.apache.httpcomponents:httpclient:4.3'

--- a/src/main/java/com/netflix/simianarmy/aws/conformity/RDSConformityClusterTracker.java
+++ b/src/main/java/com/netflix/simianarmy/aws/conformity/RDSConformityClusterTracker.java
@@ -107,7 +107,7 @@ public class RDSConformityClusterTracker implements ConformityClusterTracker {
     @Override
     public void addOrUpdate(Cluster cluster) {
     	Cluster orig = getCluster(cluster.getName(), cluster.getRegion());    	
-        LOGGER.debug(String.format("Saving cluster %s to RDB table %s", cluster.getName(), table));    	
+        LOGGER.debug(String.format("Saving cluster %s to RDB table %s in region %s", cluster.getName(), cluster.getRegion(), table));
 		Map<String, String> map = cluster.getFieldToValueMap();
 
     	String conformityJson;

--- a/src/main/java/com/netflix/simianarmy/aws/janitor/RDSJanitorResourceTracker.java
+++ b/src/main/java/com/netflix/simianarmy/aws/janitor/RDSJanitorResourceTracker.java
@@ -104,13 +104,13 @@ public class RDSJanitorResourceTracker implements JanitorResourceTracker {
 	/** {@inheritDoc} */
     @Override
     public void addOrUpdate(Resource resource) {
-    	Resource orig = getResource(resource.getId());    	
-        LOGGER.debug(String.format("Saving resource %s to RDB table %s", resource.getId(), table));    	
+    	Resource orig = getResource(resource.getId(), resource.getRegion());
+        LOGGER.debug(String.format("Saving resource %s to RDB table %s in region %s", resource.getId(), table, resource.getRegion()));
     	String json;
 		try {
 			json = new ObjectMapper().writeValueAsString(additionalFieldsAsMap(resource));
 		} catch (JsonProcessingException e) {
-			LOGGER.error("ERROR generating additonal field JSON when saving resource " + resource.getId(), e);
+			LOGGER.error("ERROR generating additional field JSON when saving resource " + resource.getId(), e);
 			return;
 		}
 
@@ -166,7 +166,8 @@ public class RDSJanitorResourceTracker implements JanitorResourceTracker {
     		sb.append(AWSResource.FIELD_MARK_TIME).append("=?,");
 			sb.append(AWSResource.FIELD_OPT_OUT_OF_JANITOR).append("=?,");
     		sb.append("additionalFields").append("=? where ");
-    		sb.append(AWSResource.FIELD_RESOURCE_ID).append("=?");
+    		sb.append(AWSResource.FIELD_RESOURCE_ID).append("=? and ");
+			sb.append(AWSResource.FIELD_REGION).append("=?");
 
             LOGGER.debug(String.format("Update statement is '%s'", sb));
     		int updated = this.jdbcTemplate.update(sb.toString(),
@@ -183,7 +184,8 @@ public class RDSJanitorResourceTracker implements JanitorResourceTracker {
     								 value(resource.getMarkTime()),
 					                 value(resource.isOptOutOfJanitor()),
     								 json,
-    								 resource.getId());
+    								 resource.getId(),
+						  			 resource.getRegion());
             LOGGER.debug(String.format("%d rows updated", updated));
     	}
     	LOGGER.debug("Successfully saved.");
@@ -309,9 +311,33 @@ public class RDSJanitorResourceTracker implements JanitorResourceTracker {
         	resource = resources.get(0);
         }
         return resource;
-    }            
-    
-    /**
+    }
+
+	@Override
+	public Resource getResource(String resourceId, String region) {
+		Validate.notEmpty(resourceId);
+		Validate.notEmpty(region);
+		StringBuilder query = new StringBuilder();
+		query.append(String.format("select * from %s where resourceId=? and region=?", table));
+
+		LOGGER.debug(String.format("Query is '%s'", query));
+		List<Resource> resources = jdbcTemplate.query(query.toString(), new String[]{resourceId,region}, new RowMapper<Resource>() {
+			public Resource mapRow(ResultSet rs, int rowNum) throws SQLException {
+				return mapResource(rs);
+			}
+		});
+
+		Resource resource = null;
+		Validate.isTrue(resources.size() <= 1);
+		if (resources.size() == 0) {
+			LOGGER.info(String.format("Not found resource with id %s", resourceId));
+		} else {
+			resource = resources.get(0);
+		}
+		return resource;
+	}
+
+	/**
      * Creates the RDS table, if it does not already exist.
      */
     public void init() {

--- a/src/main/java/com/netflix/simianarmy/basic/janitor/BasicJanitorMonkey.java
+++ b/src/main/java/com/netflix/simianarmy/basic/janitor/BasicJanitorMonkey.java
@@ -151,23 +151,38 @@ public class BasicJanitorMonkey extends JanitorMonkey {
 
     @Override
     public Event optInResource(String resourceId) {
-        return optInOrOutResource(resourceId, true);
+        return optInOrOutResource(resourceId, true, region);
     }
 
     @Override
     public Event optOutResource(String resourceId) {
-        return optInOrOutResource(resourceId, false);
+        return optInOrOutResource(resourceId, false, region);
     }
 
-    private Event optInOrOutResource(String resourceId, boolean optIn) {
-        Resource resource = resourceTracker.getResource(resourceId);
+    @Override
+    public Event optInResource(String resourceId, String resourceRegion) {
+        return optInOrOutResource(resourceId, true, resourceRegion);
+    }
+
+    @Override
+    public Event optOutResource(String resourceId, String resourceRegion) {
+        return optInOrOutResource(resourceId, false, resourceRegion);
+    }
+
+    private Event optInOrOutResource(String resourceId, boolean optIn, String resourceRegion) {
+        if (resourceRegion == null) {
+            resourceRegion = region;
+        }
+
+        Resource resource = resourceTracker.getResource(resourceId, resourceRegion);
         if (resource == null) {
             return null;
         }
+
         EventTypes eventType = optIn ? EventTypes.OPT_IN_RESOURCE : EventTypes.OPT_OUT_RESOURCE;
         long timestamp = calendar.now().getTimeInMillis();
         // The same resource can have multiple events, so we add the timestamp to the id.
-        Event evt = recorder.newEvent(Type.JANITOR, eventType, region, resourceId + "@" + timestamp);
+        Event evt = recorder.newEvent(Type.JANITOR, eventType, resourceRegion, resourceId + "@" + timestamp);
         recorder.recordEvent(evt);
         resource.setOptOutOfJanitor(!optIn);
         resourceTracker.addOrUpdate(resource);

--- a/src/main/java/com/netflix/simianarmy/client/aws/AWSClient.java
+++ b/src/main/java/com/netflix/simianarmy/client/aws/AWSClient.java
@@ -21,54 +21,16 @@ import com.amazonaws.AmazonServiceException;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.autoscaling.AmazonAutoScalingClient;
-import com.amazonaws.services.autoscaling.model.AutoScalingGroup;
-import com.amazonaws.services.autoscaling.model.AutoScalingInstanceDetails;
-import com.amazonaws.services.autoscaling.model.DeleteAutoScalingGroupRequest;
-import com.amazonaws.services.autoscaling.model.DeleteLaunchConfigurationRequest;
-import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsRequest;
-import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsResult;
-import com.amazonaws.services.autoscaling.model.DescribeAutoScalingInstancesRequest;
-import com.amazonaws.services.autoscaling.model.DescribeAutoScalingInstancesResult;
-import com.amazonaws.services.autoscaling.model.DescribeLaunchConfigurationsRequest;
-import com.amazonaws.services.autoscaling.model.DescribeLaunchConfigurationsResult;
-import com.amazonaws.services.autoscaling.model.LaunchConfiguration;
+import com.amazonaws.services.autoscaling.model.*;
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.AmazonEC2Client;
-import com.amazonaws.services.ec2.model.CreateSecurityGroupRequest;
-import com.amazonaws.services.ec2.model.CreateSecurityGroupResult;
-import com.amazonaws.services.ec2.model.CreateTagsRequest;
-import com.amazonaws.services.ec2.model.DeleteSnapshotRequest;
-import com.amazonaws.services.ec2.model.DeleteVolumeRequest;
-import com.amazonaws.services.ec2.model.DeregisterImageRequest;
-import com.amazonaws.services.ec2.model.DescribeImagesRequest;
-import com.amazonaws.services.ec2.model.DescribeImagesResult;
-import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
-import com.amazonaws.services.ec2.model.DescribeInstancesResult;
-import com.amazonaws.services.ec2.model.DescribeSecurityGroupsRequest;
-import com.amazonaws.services.ec2.model.DescribeSecurityGroupsResult;
-import com.amazonaws.services.ec2.model.DescribeSnapshotsRequest;
-import com.amazonaws.services.ec2.model.DescribeSnapshotsResult;
-import com.amazonaws.services.ec2.model.DescribeVolumesRequest;
-import com.amazonaws.services.ec2.model.DescribeVolumesResult;
-import com.amazonaws.services.ec2.model.DetachVolumeRequest;
-import com.amazonaws.services.ec2.model.EbsInstanceBlockDevice;
-import com.amazonaws.services.ec2.model.Image;
+import com.amazonaws.services.ec2.model.*;
 import com.amazonaws.services.ec2.model.Instance;
-import com.amazonaws.services.ec2.model.InstanceBlockDeviceMapping;
-import com.amazonaws.services.ec2.model.ModifyInstanceAttributeRequest;
-import com.amazonaws.services.ec2.model.Reservation;
-import com.amazonaws.services.ec2.model.SecurityGroup;
-import com.amazonaws.services.ec2.model.Snapshot;
 import com.amazonaws.services.ec2.model.Tag;
-import com.amazonaws.services.ec2.model.TerminateInstancesRequest;
-import com.amazonaws.services.ec2.model.Volume;
 import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancingClient;
-import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancerAttributesRequest;
-import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancerAttributesResult;
+import com.amazonaws.services.elasticloadbalancing.model.*;
 import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersRequest;
 import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersResult;
-import com.amazonaws.services.elasticloadbalancing.model.LoadBalancerAttributes;
-import com.amazonaws.services.elasticloadbalancing.model.LoadBalancerDescription;
 import com.amazonaws.services.simpledb.AmazonSimpleDB;
 import com.amazonaws.services.simpledb.AmazonSimpleDBClient;
 import com.google.common.base.Objects;
@@ -79,7 +41,6 @@ import com.google.common.collect.Sets;
 import com.google.inject.Module;
 import com.netflix.simianarmy.CloudClient;
 import com.netflix.simianarmy.NotFoundException;
-
 import org.apache.commons.lang.Validate;
 import org.jclouds.ContextBuilder;
 import org.jclouds.compute.ComputeService;
@@ -89,20 +50,13 @@ import org.jclouds.compute.domain.ComputeMetadata;
 import org.jclouds.compute.domain.NodeMetadata;
 import org.jclouds.compute.domain.NodeMetadataBuilder;
 import org.jclouds.domain.LoginCredentials;
-import org.jclouds.ec2.EC2ApiMetadata;
 import org.jclouds.logging.slf4j.config.SLF4JLoggingModule;
 import org.jclouds.ssh.SshClient;
 import org.jclouds.ssh.jsch.config.JschSshClientModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 
 /**
@@ -515,8 +469,13 @@ public class AWSClient implements CloudClient {
         LOGGER.info(String.format("Deleting auto-scaling group with name %s in region %s.", asgName, region));
         AmazonAutoScalingClient asgClient = asgClient();
         DeleteAutoScalingGroupRequest request = new DeleteAutoScalingGroupRequest()
-        .withAutoScalingGroupName(asgName);
-        asgClient.deleteAutoScalingGroup(request);
+        .withAutoScalingGroupName(asgName).withForceDelete(true);
+        try {
+            asgClient.deleteAutoScalingGroup(request);
+            LOGGER.info(String.format("Deleted auto-scaling group with name %s in region %s.", asgName, region));
+        }catch(Exception e) {
+            LOGGER.error("Got an exception deleting ASG " + asgName, e);
+        }
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/com/netflix/simianarmy/janitor/JanitorMonkey.java
+++ b/src/main/java/com/netflix/simianarmy/janitor/JanitorMonkey.java
@@ -17,13 +17,13 @@
  */
 package com.netflix.simianarmy.janitor;
 
-import java.util.List;
-
 import com.netflix.simianarmy.EventType;
 import com.netflix.simianarmy.Monkey;
 import com.netflix.simianarmy.MonkeyConfiguration;
 import com.netflix.simianarmy.MonkeyRecorder.Event;
 import com.netflix.simianarmy.MonkeyType;
+
+import java.util.List;
 
 /**
  * The abstract class for a Janitor Monkey.
@@ -149,5 +149,21 @@ public abstract class JanitorMonkey extends Monkey {
      * @return the opt-out event
      */
     public abstract Event optOutResource(String resourceId);
+
+    /**
+     * Opt in a resource for Janitor Monkey.
+     * @param resourceId the resource id
+     * @param region the region of the resource
+     * @return the opt-in event
+     */
+    public abstract Event optInResource(String resourceId, String region);
+
+    /**
+     * Opt out a resource for Janitor Monkey.
+     * @param resourceId the resource id
+     * @param region the region of the resource
+     * @return the opt-out event
+     */
+    public abstract Event optOutResource(String resourceId, String region);
 
 }

--- a/src/main/java/com/netflix/simianarmy/janitor/JanitorResourceTracker.java
+++ b/src/main/java/com/netflix/simianarmy/janitor/JanitorResourceTracker.java
@@ -17,10 +17,10 @@
  */
 package com.netflix.simianarmy.janitor;
 
-import java.util.List;
-
 import com.netflix.simianarmy.Resource;
 import com.netflix.simianarmy.ResourceType;
+
+import java.util.List;
 
 /**
  * The interface to track the resources marked/cleaned by the Janitor Monkey.
@@ -51,5 +51,13 @@ public interface JanitorResourceTracker {
      * @return the resource that matches the resource id
      */
     Resource getResource(String resourceId);
+
+    /** Gets the resource of a specific id.
+     *
+     * @param resourceId the resource id
+     * @param regionId the region id
+     * @return the resource that matches the resource id and region
+     */
+    Resource getResource(String resourceId, String regionId);
 
 }

--- a/src/main/java/com/netflix/simianarmy/resources/janitor/JanitorMonkeyResource.java
+++ b/src/main/java/com/netflix/simianarmy/resources/janitor/JanitorMonkeyResource.java
@@ -86,7 +86,7 @@ public class JanitorMonkeyResource {
      * @throws IOException
      */
     @GET @Path("addEvent")
-    public Response addEventThroughHttpGet( @QueryParam("eventType") String eventType,  @QueryParam("resourceId") String resourceId) throws IOException {
+    public Response addEventThroughHttpGet( @QueryParam("eventType") String eventType,  @QueryParam("resourceId") String resourceId,  @QueryParam("region") String region) throws IOException {
         Response.Status responseStatus;
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         baos.write("<html><body style=\"text-align:center\"><img src=\"https://raw.githubusercontent.com/Netflix/SimianArmy/master/assets/janitor.png\" height=\"300\" width=\"300\"><br/>".getBytes());
@@ -101,9 +101,9 @@ public class JanitorMonkeyResource {
             gen.writeStringField("resourceId", resourceId);
 
         	if (eventType.equals("OPTIN")) {
-                responseStatus = optInResource(resourceId, true, gen);
+                responseStatus = optInResource(resourceId, true, region, gen);
             } else if (eventType.equals("OPTOUT")) {
-                responseStatus = optInResource(resourceId, false, gen);
+                responseStatus = optInResource(resourceId, false, region, gen);
             } else {
                 responseStatus = Response.Status.BAD_REQUEST;
                 gen.writeStringField("message", String.format("Unrecognized event type: %s", eventType));
@@ -141,6 +141,7 @@ public class JanitorMonkeyResource {
 
         String eventType = getStringField(input, "eventType");
         String resourceId = getStringField(input, "resourceId");
+        String region = getStringField(input, "region");
 
         Response.Status responseStatus;
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -154,9 +155,9 @@ public class JanitorMonkeyResource {
             gen.writeStringField("message", "eventType and resourceId parameters are all required");
         } else {
             if (eventType.equals("OPTIN")) {
-                responseStatus = optInResource(resourceId, true, gen);
+                responseStatus = optInResource(resourceId, true, region, gen);
             } else if (eventType.equals("OPTOUT")) {
-                responseStatus = optInResource(resourceId, false, gen);
+                responseStatus = optInResource(resourceId, false, region, gen);
             } else {
                 responseStatus = Response.Status.BAD_REQUEST;
                 gen.writeStringField("message", String.format("Unrecognized event type: %s", eventType));
@@ -191,16 +192,16 @@ public class JanitorMonkeyResource {
         return Response.status(Response.Status.OK).entity(baos.toString("UTF-8")).build();
     }
 
-    private Response.Status optInResource(String resourceId, boolean optIn, JsonGenerator gen)
+    private Response.Status optInResource(String resourceId, boolean optIn, String region, JsonGenerator gen)
             throws IOException {
         String op = optIn ? "in" : "out";
         LOGGER.info(String.format("Opt %s resource %s for Janitor Monkey.", op, resourceId));
         Response.Status responseStatus;
         Event evt;
         if (optIn) {
-            evt = monkey.optInResource(resourceId);
+            evt = monkey.optInResource(resourceId, region);
         } else {
-            evt = monkey.optOutResource(resourceId);
+            evt = monkey.optOutResource(resourceId, region);
         }
         if (evt != null) {
             responseStatus = Response.Status.OK;

--- a/src/main/java/com/netflix/simianarmy/resources/janitor/JanitorMonkeyResource.java
+++ b/src/main/java/com/netflix/simianarmy/resources/janitor/JanitorMonkeyResource.java
@@ -20,20 +20,6 @@ package com.netflix.simianarmy.resources.janitor;
 import com.netflix.simianarmy.MonkeyRecorder.Event;
 import com.netflix.simianarmy.MonkeyRunner;
 import com.netflix.simianarmy.janitor.JanitorMonkey;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.util.Map;
-
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriInfo;
-
 import org.apache.commons.lang.StringUtils;
 import org.codehaus.jackson.JsonEncoding;
 import org.codehaus.jackson.JsonGenerator;
@@ -58,7 +44,6 @@ import java.util.Map;
  * The Class JanitorMonkeyResource for json REST apis.
  */
 @Path("/v1/janitor")
-@Produces(MediaType.APPLICATION_JSON)
 public class JanitorMonkeyResource {
 
     /** The Constant JSON_FACTORY. */

--- a/src/main/java/com/netflix/simianarmy/tunable/TunableInstanceGroup.java
+++ b/src/main/java/com/netflix/simianarmy/tunable/TunableInstanceGroup.java
@@ -1,3 +1,20 @@
+/*
+ *
+ *  Copyright 2012 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
 package com.netflix.simianarmy.tunable;
 
 import com.amazonaws.services.autoscaling.model.TagDescription;

--- a/src/main/java/com/netflix/simianarmy/tunable/TunablyAggressiveChaosMonkey.java
+++ b/src/main/java/com/netflix/simianarmy/tunable/TunablyAggressiveChaosMonkey.java
@@ -1,3 +1,20 @@
+/*
+ *
+ *  Copyright 2012 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
 package com.netflix.simianarmy.tunable;
 
 import com.netflix.simianarmy.basic.chaos.BasicChaosMonkey;

--- a/src/test/java/com/netflix/simianarmy/aws/TestAWSEmailNotifier.java
+++ b/src/test/java/com/netflix/simianarmy/aws/TestAWSEmailNotifier.java
@@ -1,3 +1,20 @@
+/*
+ *
+ *  Copyright 2012 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
 package com.netflix.simianarmy.aws;
 
 import org.testng.Assert;

--- a/src/test/java/com/netflix/simianarmy/aws/conformity/TestASGOwnerEmailTag.java
+++ b/src/test/java/com/netflix/simianarmy/aws/conformity/TestASGOwnerEmailTag.java
@@ -1,28 +1,41 @@
+/*
+ *
+ *  Copyright 2012 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
 // CHECKSTYLE IGNORE Javadoc
 package com.netflix.simianarmy.aws.conformity;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import com.amazonaws.services.autoscaling.model.AutoScalingGroup;
-import com.amazonaws.services.autoscaling.model.SuspendedProcess;
 import com.amazonaws.services.autoscaling.model.TagDescription;
-
 import com.google.common.collect.Maps;
-
 import com.netflix.simianarmy.aws.conformity.crawler.AWSClusterCrawler;
 import com.netflix.simianarmy.basic.BasicConfiguration;
 import com.netflix.simianarmy.basic.conformity.BasicConformityMonkeyContext;
-import com.netflix.simianarmy.conformity.Cluster;
 import com.netflix.simianarmy.client.aws.AWSClient;
-
+import com.netflix.simianarmy.conformity.Cluster;
 import junit.framework.Assert;
 import org.testng.annotations.Test;
 
-import java.util.Map;
-import java.util.List;
 import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.Properties;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TestASGOwnerEmailTag {
     

--- a/src/test/java/com/netflix/simianarmy/aws/janitor/TestRDSJanitorResourceTracker.java
+++ b/src/test/java/com/netflix/simianarmy/aws/janitor/TestRDSJanitorResourceTracker.java
@@ -175,12 +175,13 @@ public class TestRDSJanitorResourceTracker extends RDSJanitorResourceTracker {
         		                              objCap.capture(),  
         		                              objCap.capture(),
                                               objCap.capture(),
+                                              objCap.capture(),
                                               objCap.capture())).thenReturn(1);
         tracker.addOrUpdate(newResource);
 
         List<Object> args = objCap.getAllValues();        
-        Assert.assertEquals(sqlCap.getValue(), "update janitortable set resourceType=?,region=?,ownerEmail=?,description=?,state=?,terminationReason=?,expectedTerminationTime=?,actualTerminationTime=?,notificationTime=?,launchTime=?,markTime=?,optOutOfJanitor=?,additionalFields=? where resourceId=?");
-        Assert.assertEquals(args.size(), 14);
+        Assert.assertEquals(sqlCap.getValue(), "update janitortable set resourceType=?,region=?,ownerEmail=?,description=?,state=?,terminationReason=?,expectedTerminationTime=?,actualTerminationTime=?,notificationTime=?,launchTime=?,markTime=?,optOutOfJanitor=?,additionalFields=? where resourceId=? and region=?");
+        Assert.assertEquals(args.size(), 15);
         Assert.assertEquals(args.get(0).toString(), AWSResourceType.INSTANCE.toString());
         Assert.assertEquals(args.get(1).toString(), region);
         Assert.assertEquals(args.get(2).toString(), ownerEmail);
@@ -195,6 +196,7 @@ public class TestRDSJanitorResourceTracker extends RDSJanitorResourceTracker {
         Assert.assertEquals(args.get(11).toString(), "false");
         Assert.assertEquals(args.get(12).toString(), "{\"fieldName123\":\"fieldValue456\"}");
         Assert.assertEquals(args.get(13).toString(), id);
+        Assert.assertEquals(args.get(14).toString(), region);
     }
 
     

--- a/src/test/java/com/netflix/simianarmy/janitor/TestAbstractJanitor.java
+++ b/src/test/java/com/netflix/simianarmy/janitor/TestAbstractJanitor.java
@@ -20,32 +20,17 @@
 
 package com.netflix.simianarmy.janitor;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Date;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-
-import org.joda.time.DateTime;
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
-import com.netflix.simianarmy.MonkeyCalendar;
-import com.netflix.simianarmy.MonkeyConfiguration;
-import com.netflix.simianarmy.MonkeyRecorder;
-import com.netflix.simianarmy.Resource;
+import com.netflix.simianarmy.*;
 import com.netflix.simianarmy.Resource.CleanupState;
-import com.netflix.simianarmy.ResourceType;
 import com.netflix.simianarmy.aws.AWSResource;
 import com.netflix.simianarmy.aws.janitor.rule.TestMonkeyCalendar;
 import com.netflix.simianarmy.basic.BasicConfiguration;
 import com.netflix.simianarmy.basic.janitor.BasicJanitorRuleEngine;
+import org.joda.time.DateTime;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.*;
 
 
 public class TestAbstractJanitor extends AbstractJanitor {
@@ -563,6 +548,12 @@ class TestJanitorResourceTracker implements JanitorResourceTracker {
     public Resource getResource(String resourceId) {
         return resources.get(resourceId);
     }
+
+    @Override
+    public Resource getResource(String resourceId, String region) {
+        return resources.get(resourceId);
+    }
+
 }
 
 /**

--- a/src/test/java/com/netflix/simianarmy/janitor/TestBasicJanitorMonkeyContext.java
+++ b/src/test/java/com/netflix/simianarmy/janitor/TestBasicJanitorMonkeyContext.java
@@ -1,11 +1,25 @@
+/*
+ *
+ *  Copyright 2012 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
 package com.netflix.simianarmy.janitor;
 
 import com.netflix.simianarmy.aws.janitor.rule.generic.UntaggedRule;
 import com.netflix.simianarmy.basic.TestBasicCalendar;
 import com.netflix.simianarmy.basic.janitor.BasicJanitorRuleEngine;
-import com.netflix.simianarmy.janitor.JanitorRuleEngine;
-import com.netflix.simianarmy.janitor.Rule;
-
 import org.apache.commons.lang.StringUtils;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;

--- a/src/test/java/com/netflix/simianarmy/tunable/TestTunablyAggressiveChaosMonkey.java
+++ b/src/test/java/com/netflix/simianarmy/tunable/TestTunablyAggressiveChaosMonkey.java
@@ -1,3 +1,20 @@
+/*
+ *
+ *  Copyright 2012 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
 package com.netflix.simianarmy.tunable;
 
 import com.amazonaws.services.autoscaling.model.TagDescription;


### PR DESCRIPTION
Three changes for Netflix environment compatibility:

- Upgrade AWS client to 1.11.9
- Set force delete instances=true when deleting ASGs
- Don't set MediaType on JanitorMonkeyResource (undo Janitor part of PR#261)

The first change is straightforward, AWS client update.

For the second change, if Janitor already made the decision to delete the ASG then there is no reason to keep the instances. Feedback welcome if anyone feels this is too aggressive.  

The third change exposes a fundamental problem with JanitorMonkeyResource.  Technically the return type should be JSON as it is a REST API but some routines return HTML!  There probably should be separate APIs for JSON vs. HTML returns.  But for now we are removing the explicit JSON return type on the JanitorMonkeyResource as it breaks our internal apps that are expecting HTML.   