### PR TITLE
added ability to terminate based on ec2 tags.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,15 @@ apply plugin: 'jetty'
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
+configurations.all {
+    resolutionStrategy.eachDependency() {
+        DependencyResolveDetails details ->
+            if (details.requested.group == 'com.google.inject.extensions') {
+                details.useVersion '4.0'
+            }
+    }
+}
+
 dependencies {
     // for the VMWareClient
     compile 'com.cloudbees.thirdparty:vijava:5.0.0'
@@ -43,10 +52,10 @@ dependencies {
     compile 'com.google.guava:guava:11.0.2'
     compile 'org.apache.httpcomponents:httpclient:4.3'
     compile 'com.google.auto.service:auto-service:1.0-rc2'
-    compile 'org.apache.jclouds.driver:jclouds-jsch:1.9.0'
-    compile 'org.apache.jclouds.driver:jclouds-slf4j:1.9.0'
-    compile 'org.apache.jclouds.api:ec2:1.9.0'
-    compile 'org.apache.jclouds.provider:aws-ec2:1.9.0'
+    compile 'org.apache.jclouds.driver:jclouds-jsch:2.0.0'
+    compile 'org.apache.jclouds.driver:jclouds-slf4j:2.0.0'
+    compile 'org.apache.jclouds.api:ec2:2.0.0'
+    compile 'org.apache.jclouds.provider:aws-ec2:2.0.0'
     compile 'com.netflix.servo:servo-core:0.12.11'
     compile 'org.springframework:spring-jdbc:4.2.5.RELEASE'
     compile 'com.zaxxer:HikariCP:2.4.7'

--- a/src/main/java/com/netflix/simianarmy/Instance.java
+++ b/src/main/java/com/netflix/simianarmy/Instance.java
@@ -1,0 +1,59 @@
+/*
+ *
+ *  Copyright 2012 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.simianarmy;
+
+import com.netflix.simianarmy.Tag;
+import java.util.List;
+
+
+/**
+ * The interface that holds the EC2 instance metadata
+ */
+
+public interface Instance {
+
+    /**
+     * Gets instance id.
+     *
+     * @return instance id as string
+     */
+    String getInstanceId();
+
+    /**
+     * Gets name.
+     *
+     * @return name as string
+     */
+    String getName();
+
+    /**
+     * Gets host name.
+     *
+     * @return host name as string
+     */
+    String getHostname();
+
+    /**
+     * Gets the user created tags for the instance.
+     *
+     * @return list of tags
+     */
+    List<Tag> getTags();
+
+
+}

--- a/src/main/java/com/netflix/simianarmy/NoInstanceWithTagsFoundException.java
+++ b/src/main/java/com/netflix/simianarmy/NoInstanceWithTagsFoundException.java
@@ -1,0 +1,55 @@
+/*
+ *
+ *  Copyright 2012 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.simianarmy;
+import com.netflix.simianarmy.Tag;
+
+import java.util.List;
+
+/**
+ * The Class NoInstanceWithTagsFoundException.
+ *
+ * These exceptions will be thrown when an instance with all tags are NOT found
+ */
+public class NoInstanceWithTagsFoundException extends Exception {
+    private static final long serialVersionUID = 01072016L;
+    private List<Tag> ec2Tags;
+
+    /**
+     * Instantiates an NoInstanceWithTagsFoundException with the tags.
+     * @param ec2Tags
+     */
+    public NoInstanceWithTagsFoundException(List<Tag> ec2Tags) {
+        super(errorMessage(ec2Tags));
+        this.ec2Tags = ec2Tags;
+    }
+
+    @Override
+    public String toString() {
+        return errorMessage(ec2Tags);
+    }
+
+    private static String errorMessage(List<Tag> ec2Tags) {
+        StringBuilder error = new StringBuilder(1000);
+        error.append(" No Instances with the following tags were found: ");
+        for (Tag ec2Tag : ec2Tags) {
+            error.append(ec2Tag.getKey() + ":" +  ec2Tag.getValue() + ", ");
+        }
+        return error.toString();
+    }
+}

--- a/src/main/java/com/netflix/simianarmy/Tag.java
+++ b/src/main/java/com/netflix/simianarmy/Tag.java
@@ -1,0 +1,78 @@
+/*
+ *
+ *  Copyright 2012 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.simianarmy;
+
+import java.util.Objects;
+
+/**
+ * The Class that holds the EC2 tags in name value pair.
+ */
+public class Tag {
+
+    private String key;
+    private String value;
+
+    public Tag() {}
+
+    public Tag(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return "Tag{" +
+                "key='" + key + '\'' +
+                ", value='" + value + '\'' +
+                '}';
+    }
+
+    @Override
+    public int hashCode() {
+        return (key+value).hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Tag tag = (Tag) obj;
+        return Objects.equals(key, tag.getKey())
+                && Objects.equals(value, tag.getValue());
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setName(String key) {
+        this.key = key;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/com/netflix/simianarmy/basic/BasicInstance.java
+++ b/src/main/java/com/netflix/simianarmy/basic/BasicInstance.java
@@ -1,0 +1,62 @@
+/*
+ *
+ *  Copyright 2012 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.netflix.simianarmy.basic;
+
+import com.netflix.simianarmy.Instance;
+import com.netflix.simianarmy.Tag;
+
+import java.util.List;
+
+public class BasicInstance implements Instance {
+
+    private String instanceId;
+    private String name;
+    private String hostName;
+    private List<Tag> tags;
+
+    public BasicInstance(String instanceId) {
+        this.instanceId = instanceId;
+    }
+
+    public BasicInstance(String instanceId, String name, String hostName, List<Tag> tags) {
+        this.instanceId = instanceId;
+        this.name       = name;
+        this.hostName   = hostName;
+        this.tags       = tags;
+    }
+
+    @Override
+    public String getInstanceId() {
+        return instanceId;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getHostname() {
+        return hostName;
+    }
+
+    @Override
+    public List<Tag> getTags() {
+        return tags;
+    }
+}

--- a/src/main/java/com/netflix/simianarmy/basic/chaos/BasicInstanceGroup.java
+++ b/src/main/java/com/netflix/simianarmy/basic/chaos/BasicInstanceGroup.java
@@ -17,12 +17,14 @@
  */
 package com.netflix.simianarmy.basic.chaos;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
 import com.amazonaws.services.autoscaling.model.TagDescription;
 import com.netflix.simianarmy.GroupType;
+import com.netflix.simianarmy.Instance;
 import com.netflix.simianarmy.chaos.ChaosCrawler.InstanceGroup;
 
 /**
@@ -82,17 +84,26 @@ public class BasicInstanceGroup implements InstanceGroup {
     }
 
     /** The list. */
-    private List<String> list = new LinkedList<String>();
+    private List<Instance> list = new LinkedList<Instance>();
 
     /** {@inheritDoc} */
     @Override
-    public List<String> instances() {
+    public List<Instance> instances() {
         return Collections.unmodifiableList(list);
+    }
+
+    @Override
+    public List<String> instanceIds() {
+        List<String> instanceIds = new ArrayList<String>();
+        for (Instance instance : list) {
+            instanceIds.add(instance.getInstanceId());
+        }
+        return Collections.unmodifiableList(instanceIds);
     }
 
     /** {@inheritDoc} */
     @Override
-    public void addInstance(String instance) {
+    public void addInstance(Instance instance) {
         list.add(instance);
     }
 
@@ -100,9 +111,15 @@ public class BasicInstanceGroup implements InstanceGroup {
     @Override
     public BasicInstanceGroup copyAs(String newName) {
         BasicInstanceGroup newGroup = new BasicInstanceGroup(newName, this.type(), this.region(), this.tags());
-        for (String instance: this.instances()) {
+        for (Instance instance: this.instances()) {
             newGroup.addInstance(instance);
         }
         return newGroup;
     }
+
+    @Override
+    public void addInstanceList(List<Instance> instances) {
+        //need to add
+        list.addAll(instances);
+    };
 }

--- a/src/main/java/com/netflix/simianarmy/chaos/ChaosCrawler.java
+++ b/src/main/java/com/netflix/simianarmy/chaos/ChaosCrawler.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import com.amazonaws.services.autoscaling.model.TagDescription;
 import com.netflix.simianarmy.GroupType;
+import com.netflix.simianarmy.Instance;
 
 /**
  * The Interface ChaosCrawler.
@@ -66,15 +67,22 @@ public interface ChaosCrawler {
          *
          * @return the list of instances
          */
-        List<String> instances();
+        List<Instance> instances();
+
+        /**
+         * Instances Ids as Strings.
+         *
+         * @return the list list of instances as strings
+         */
+        List<String> instanceIds();
 
         /**
          * Adds the instance.
          *
          * @param instance
-         *            the instance
+         *
          */
-        void addInstance(String instance);
+        void addInstance(Instance instance);
 
         /**
          * Copies the Instance group replacing its name with
@@ -85,6 +93,15 @@ public interface ChaosCrawler {
          * @return the new instance group
          */
         InstanceGroup copyAs(String name);
+
+        /**
+         * Adds the list of instances
+         * the supplied name.
+         *
+         * @param instanceIds
+         *
+         */
+        void addInstanceList(List<Instance> instanceIds);
     }
 
     /**

--- a/src/main/java/com/netflix/simianarmy/chaos/ChaosInstanceSelector.java
+++ b/src/main/java/com/netflix/simianarmy/chaos/ChaosInstanceSelector.java
@@ -17,9 +17,12 @@
  */
 package com.netflix.simianarmy.chaos;
 
+import com.netflix.simianarmy.NoInstanceWithTagsFoundException;
+import com.netflix.simianarmy.Tag;
 import com.netflix.simianarmy.chaos.ChaosCrawler.InstanceGroup;
 
 import java.util.Collection;
+import java.util.List;
 
 /**
  * The Interface ChaosInstanceSelector.
@@ -52,4 +55,6 @@ public interface ChaosInstanceSelector {
      * @return the instance
      */
     Collection<String> select(InstanceGroup group, double probability);
+
+    Collection<String> selectOneByTags(InstanceGroup group, List<Tag> ec2TagsSent) throws NoInstanceWithTagsFoundException;
 }

--- a/src/main/java/com/netflix/simianarmy/chaos/ChaosMonkey.java
+++ b/src/main/java/com/netflix/simianarmy/chaos/ChaosMonkey.java
@@ -20,13 +20,8 @@ package com.netflix.simianarmy.chaos;
 import java.util.Date;
 import java.util.List;
 
-import com.netflix.simianarmy.EventType;
-import com.netflix.simianarmy.FeatureNotEnabledException;
-import com.netflix.simianarmy.InstanceGroupNotFoundException;
-import com.netflix.simianarmy.Monkey;
-import com.netflix.simianarmy.MonkeyConfiguration;
+import com.netflix.simianarmy.*;
 import com.netflix.simianarmy.MonkeyRecorder.Event;
-import com.netflix.simianarmy.MonkeyType;
 
 /**
  * The Class ChaosMonkey.
@@ -147,8 +142,8 @@ public abstract class ChaosMonkey extends Monkey {
      * @throws FeatureNotEnabledException
      * @throws InstanceGroupNotFoundException
      */
-    public abstract Event terminateNow(String type, String name, ChaosType chaosType)
-            throws FeatureNotEnabledException, InstanceGroupNotFoundException;
+    public abstract Event terminateNow(String type, String name, ChaosType chaosType, List<Tag> ec2TagsSent)
+            throws FeatureNotEnabledException, InstanceGroupNotFoundException, NoInstanceWithTagsFoundException;
 
     /**
      * Sends notification for the termination to the instance owners.

--- a/src/main/java/com/netflix/simianarmy/client/MonkeyRestClient.java
+++ b/src/main/java/com/netflix/simianarmy/client/MonkeyRestClient.java
@@ -109,6 +109,7 @@ public abstract class MonkeyRestClient {
     public abstract String getBaseUrl(String region);
 
     public static class DataReadException extends RuntimeException {
+        private static final long serialVersionUID = 101072016L;
         public DataReadException(int code, String url, String jsonContent) {
             super(String.format("Response code %d from url %s: %s", code, url, jsonContent));
         }

--- a/src/main/java/com/netflix/simianarmy/client/aws/AWSClient.java
+++ b/src/main/java/com/netflix/simianarmy/client/aws/AWSClient.java
@@ -46,6 +46,7 @@ import com.google.common.collect.Sets;
 import com.google.inject.Module;
 import com.netflix.simianarmy.CloudClient;
 import com.netflix.simianarmy.NotFoundException;
+import com.netflix.simianarmy.basic.chaos.BasicInstanceGroup;
 import org.apache.commons.lang.Validate;
 import org.jclouds.ContextBuilder;
 import org.jclouds.compute.ComputeService;
@@ -953,7 +954,6 @@ public class AWSClient implements CloudClient {
         if (Strings.isNullOrEmpty(vpcId)) {
             return null;
         }
-
         return vpcId;
     }
 
@@ -961,5 +961,31 @@ public class AWSClient implements CloudClient {
     @Override
     public boolean canChangeInstanceSecurityGroups(String instanceId) {
         return null != getVpcId(instanceId);
+    }
+
+    public List<com.netflix.simianarmy.Instance> convertToSimianArmyInstance(List<Instance> ec2InstList) {
+        if (ec2InstList != null) {
+            List<com.netflix.simianarmy.Instance> instList = new ArrayList<>();
+
+            for (Instance ec2Inst : ec2InstList) {
+                List<com.netflix.simianarmy.Tag> ec2Tags = new ArrayList<>();
+                if (ec2Inst.getTags() != null) {
+                    for (Tag ec2Tag : ec2Inst.getTags()) {
+                        com.netflix.simianarmy.Tag SimianArmyTag = new com.netflix.simianarmy.Tag(ec2Tag.getKey(), ec2Tag.getValue());
+                        ec2Tags.add(SimianArmyTag);
+                    }
+                }
+
+                com.netflix.simianarmy.Instance SimianArmyInst = new com.netflix.simianarmy.basic.BasicInstance(
+                        ec2Inst.getInstanceId(),
+                        ec2Inst.getKeyName(),
+                        ec2Inst.getPublicDnsName(),
+                        ec2Tags);
+                instList.add(SimianArmyInst);
+            }
+
+            return instList;
+        }
+        return null;
     }
 }

--- a/src/test/java/com/netflix/simianarmy/basic/chaos/TestBasicChaosInstanceSelector.java
+++ b/src/test/java/com/netflix/simianarmy/basic/chaos/TestBasicChaosInstanceSelector.java
@@ -24,6 +24,8 @@ import com.amazonaws.services.autoscaling.model.TagDescription;
 import com.netflix.simianarmy.GroupType;
 import com.netflix.simianarmy.chaos.ChaosInstanceSelector;
 import com.netflix.simianarmy.chaos.ChaosCrawler.InstanceGroup;
+import com.netflix.simianarmy.Instance;
+import com.netflix.simianarmy.basic.BasicInstance;
 
 import org.testng.annotations.Test;
 import org.testng.annotations.DataProvider;
@@ -46,6 +48,40 @@ public class TestBasicChaosInstanceSelector {
     }
 
     private InstanceGroup group = new InstanceGroup() {
+
+        List<Instance> instancesList = new ArrayList<Instance>();
+        {
+            Instance i1 = new BasicInstance("i-123456789012345670");
+            instancesList.add(i1);
+
+            Instance i2 = new BasicInstance("i-123456789012345671");
+            instancesList.add(i2);
+
+            Instance i3 = new BasicInstance("i-123456789012345672");
+            instancesList.add(i3);
+
+            Instance i4 = new BasicInstance("i-123456789012345673");
+            instancesList.add(i4);
+
+            Instance i5 = new BasicInstance("i-123456789012345674");
+            instancesList.add(i5);
+
+            Instance i6 = new BasicInstance("i-123456789012345675");
+            instancesList.add(i6);
+
+            Instance i7 = new BasicInstance("i-123456789012345676");
+            instancesList.add(i7);
+
+            Instance i8 = new BasicInstance("i-123456789012345677");
+            instancesList.add(i8);
+
+            Instance i9 = new BasicInstance("i-123456789012345678");
+            instancesList.add(i9);
+
+            Instance i10 = new BasicInstance("i-123456789012345679");
+            instancesList.add(i10);
+        }
+
         public GroupType type() {
             return Types.TEST;
         }
@@ -62,9 +98,20 @@ public class TestBasicChaosInstanceSelector {
             return Collections.<TagDescription>emptyList();
         }
 
-        public List<String> instances() {
-            return Arrays.asList("i-123456789012345670", "i-123456789012345671", "i-123456789012345672", "i-123456789012345673", "i-123456789012345674",
-                    "i-123456789012345675", "i-123456789012345676", "i-123456789012345677", "i-123456789012345678", "i-123456789012345679");
+        public List<String> instanceIds() {
+            List<String> instanceIdsList = new ArrayList<String>();
+            for (Instance inst : instancesList) {
+                instanceIdsList.add(inst.getInstanceId());
+            }
+            return instanceIdsList;
+        }
+
+        @Override
+        public void addInstance(Instance instance) {
+        }
+
+        public List<Instance> instances() {
+            return instancesList;
         }
 
         public void addInstance(String ignored) {
@@ -74,6 +121,12 @@ public class TestBasicChaosInstanceSelector {
         public InstanceGroup copyAs(String name) {
             return this;
         }
+
+        @Override
+        public void addInstanceList(List<Instance> instance) {
+            instancesList.addAll(instance);
+        }
+
     };
 
     @Test


### PR DESCRIPTION
1. upgraded to jcloud 2.0.0 from 1.9.0 to remove the following noClassDefFoundError when attempting to do POST HTTP networklatency chaos. 
	java.lang.NoClassDefFoundError: com/google/inject/internal/util/$Preconditions

2. forced com.google.inject.extensions to be version 4.0 to remove the 2nd NoClassDefFoundError when attempting to do POST HTTP networklatency chaos.
	java.lang.NoClassDefFoundError: com/google/inject/internal/util/$Maps
	
3. BasicInstanceGroup class now holds a new BasicInstance type and not just a string. This Instance type will hold more detailed meta data of the instances, specifically the associated ec2 tags.

4. Here is a sample of the ec2 tags that are included in the JSON. Only ec2 instances that have all the matching key=value pairs will be considered for termination. Amongst these, 1 ec2 server will be randomly terminated.

{ "eventType":"CHAOS_TERMINATION", "groupType":"ASG", "groupName":"SimianMonkeyASG", "chaosType":"ShutdownInstance",
	"tags" : [
			{"key"  : "app-host-type", "value" : "reports"},
			{"key"  : "app-category", "value" : "reportServer"}			
		     ]
}

5. Unit tests were updated.