### PR TITLE
synchronize with double-checked locking in AWSClient

### DIFF
--- a/src/main/java/com/netflix/simianarmy/client/aws/AWSClient.java
+++ b/src/main/java/com/netflix/simianarmy/client/aws/AWSClient.java
@@ -856,15 +856,19 @@ public class AWSClient implements CloudClient {
 
     /** {@inheritDoc} */
     @Override
-    public synchronized ComputeService getJcloudsComputeService() {
+    public ComputeService getJcloudsComputeService() {
         if (jcloudsComputeService == null) {
-            String username = awsCredentialsProvider.getCredentials().getAWSAccessKeyId();
-            String password = awsCredentialsProvider.getCredentials().getAWSSecretKey();
-            ComputeServiceContext jcloudsContext = ContextBuilder.newBuilder("aws-ec2").credentials(username, password)
-                    .modules(ImmutableSet.<Module>of(new SLF4JLoggingModule(), new JschSshClientModule()))
-                    .buildView(ComputeServiceContext.class);
+            synchronized(this) {
+                if (jcloudsComputeService == null) {
+                    String username = awsCredentialsProvider.getCredentials().getAWSAccessKeyId();
+                    String password = awsCredentialsProvider.getCredentials().getAWSSecretKey();
+                    ComputeServiceContext jcloudsContext = ContextBuilder.newBuilder("aws-ec2").credentials(username, password)
+                            .modules(ImmutableSet.<Module>of(new SLF4JLoggingModule(), new JschSshClientModule()))
+                            .buildView(ComputeServiceContext.class);
 
-            this.jcloudsComputeService = jcloudsContext.getComputeService();
+                    this.jcloudsComputeService = jcloudsContext.getComputeService();
+                }
+            }
         }
 
         return jcloudsComputeService;


### PR DESCRIPTION
Perhaps, double-checked locking can be used to reduce the overhead of acquiring a lock by first testing "if (jcloudsComputeService == null)", aka the locking criterion,  without actually acquiring the lock. Only if the locking criterion check indicates that locking is required does the actual locking logic proceed.