### PR TITLE
Adding support for a dry run functionality when in Leashed Mode

### DIFF
--- a/src/main/java/com/netflix/simianarmy/janitor/DryRunnableJanitor.java
+++ b/src/main/java/com/netflix/simianarmy/janitor/DryRunnableJanitor.java
@@ -1,0 +1,27 @@
+/*
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.simianarmy.janitor;
+
+import com.netflix.simianarmy.Resource;
+
+public interface DryRunnableJanitor extends Janitor {
+    default void cleanupDryRun(Resource markedResource) throws DryRunnableJanitorException {
+        // NO-OP
+    }
+}

--- a/src/main/java/com/netflix/simianarmy/janitor/DryRunnableJanitorException.java
+++ b/src/main/java/com/netflix/simianarmy/janitor/DryRunnableJanitorException.java
@@ -1,0 +1,29 @@
+/*
+ *
+ *  Copyright 2017 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.simianarmy.janitor;
+
+public class DryRunnableJanitorException extends Exception {
+    public DryRunnableJanitorException(String message) {
+        super(message);
+    }
+
+    public DryRunnableJanitorException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
- Added an interface to a `DryRunnalble` Janitor
- Allowing Janitor in Leashed Mode to mark resources
- Marking a resource in Leashed mode doesn't generate an event
- A dry run cleanup should not actually cleanup the resource
- Added additional logging