### PR TITLE
Allows overriding the SimpleDB region

### DIFF
--- a/src/main/java/com/netflix/simianarmy/aws/SimpleDBRecorder.java
+++ b/src/main/java/com/netflix/simianarmy/aws/SimpleDBRecorder.java
@@ -41,6 +41,7 @@ import com.amazonaws.services.simpledb.model.PutAttributesRequest;
 import com.amazonaws.services.simpledb.model.ReplaceableAttribute;
 import com.amazonaws.services.simpledb.model.SelectRequest;
 import com.amazonaws.services.simpledb.model.SelectResult;
+import com.amazonaws.regions.Region;
 import com.netflix.simianarmy.EventType;
 import com.netflix.simianarmy.MonkeyRecorder;
 import com.netflix.simianarmy.MonkeyType;
@@ -58,7 +59,8 @@ public class SimpleDBRecorder implements MonkeyRecorder {
 
     private final AmazonSimpleDB simpleDBClient;
 
-    private final String region;
+    /** The region. */
+    private final Region region;
 
     /** The domain. */
     private final String domain;
@@ -96,14 +98,18 @@ public class SimpleDBRecorder implements MonkeyRecorder {
      *
      * @param awsClient
      *            the AWS client
+     * @param region
+     *            the AWS region
      * @param domain
      *            the domain
      */
-    public SimpleDBRecorder(AWSClient awsClient, String domain) {
+    public SimpleDBRecorder(AWSClient awsClient, Region region, String domain) {
         Validate.notNull(awsClient);
+        Validate.notNull(region);
         Validate.notNull(domain);
         this.simpleDBClient = awsClient.sdbClient();
-        this.region = awsClient.region();
+        this.simpleDBClient.setRegion(region);
+        this.region = region;
         this.domain = domain;
     }
 

--- a/src/main/java/com/netflix/simianarmy/aws/conformity/SimpleDBConformityClusterTracker.java
+++ b/src/main/java/com/netflix/simianarmy/aws/conformity/SimpleDBConformityClusterTracker.java
@@ -25,6 +25,7 @@ import com.amazonaws.services.simpledb.model.PutAttributesRequest;
 import com.amazonaws.services.simpledb.model.ReplaceableAttribute;
 import com.amazonaws.services.simpledb.model.SelectRequest;
 import com.amazonaws.services.simpledb.model.SelectResult;
+import com.amazonaws.regions.Region;
 import com.google.common.collect.Lists;
 import com.netflix.simianarmy.client.aws.AWSClient;
 import com.netflix.simianarmy.conformity.Cluster;
@@ -47,6 +48,9 @@ public class SimpleDBConformityClusterTracker implements ConformityClusterTracke
     /** The Constant LOGGER. */
     private static final Logger LOGGER = LoggerFactory.getLogger(SimpleDBConformityClusterTracker.class);
 
+    /** The region. */
+    private final Region region;
+
     /** The domain. */
     private final String domain;
 
@@ -60,14 +64,19 @@ public class SimpleDBConformityClusterTracker implements ConformityClusterTracke
      *
      * @param awsClient
      *            the AWS Client
+     * @param region
+     *            the AWS region
      * @param domain
      *            the domain
      */
-    public SimpleDBConformityClusterTracker(AWSClient awsClient, String domain) {
+    public SimpleDBConformityClusterTracker(AWSClient awsClient, Region region, String domain) {
         Validate.notNull(awsClient);
+        Validate.notNull(region);
         Validate.notNull(domain);
+        this.region = region;
         this.domain = domain;
         this.simpleDBClient = awsClient.sdbClient();
+        this.simpleDBClient.setRegion(region);
     }
 
     /**

--- a/src/main/java/com/netflix/simianarmy/aws/janitor/SimpleDBJanitorResourceTracker.java
+++ b/src/main/java/com/netflix/simianarmy/aws/janitor/SimpleDBJanitorResourceTracker.java
@@ -19,6 +19,7 @@ package com.netflix.simianarmy.aws.janitor;
 
 import com.amazonaws.services.simpledb.AmazonSimpleDB;
 import com.amazonaws.services.simpledb.model.*;
+import com.amazonaws.regions.Region;
 import com.netflix.simianarmy.Resource;
 import com.netflix.simianarmy.Resource.CleanupState;
 import com.netflix.simianarmy.ResourceType;
@@ -42,6 +43,9 @@ public class SimpleDBJanitorResourceTracker implements JanitorResourceTracker {
     /** The Constant LOGGER. */
     private static final Logger LOGGER = LoggerFactory.getLogger(SimpleDBJanitorResourceTracker.class);
 
+    /** The region. */
+    private final Region region;
+
     /** The domain. */
     private final String domain;
 
@@ -53,12 +57,16 @@ public class SimpleDBJanitorResourceTracker implements JanitorResourceTracker {
      *
      * @param awsClient
      *            the AWS Client
+     * @param region
+     *            the AWS region
      * @param domain
      *            the domain
      */
-    public SimpleDBJanitorResourceTracker(AWSClient awsClient, String domain) {
+    public SimpleDBJanitorResourceTracker(AWSClient awsClient, Region region, String domain) {
+        this.region = region;
         this.domain = domain;
         this.simpleDBClient = awsClient.sdbClient();
+        this.simpleDBClient.setRegion(region);
     }
 
     /**

--- a/src/main/java/com/netflix/simianarmy/basic/BasicSimianArmyContext.java
+++ b/src/main/java/com/netflix/simianarmy/basic/BasicSimianArmyContext.java
@@ -226,8 +226,18 @@ public class BasicSimianArmyContext implements Monkey.Context {
             setRecorder(rdsRecorder);        	
         } else if (recorderClass == null || recorderClass.equals(SimpleDBRecorder.class)) {
             String domain = config.getStrOrElse("simianarmy.recorder.sdb.domain", "SIMIAN_ARMY");
+            String region = config.getStr("simianarmy.recorder.sdb.region");
+            if (region == null) {
+                region = "us-east-1";
+                Region currentRegion = Regions.getCurrentRegion();
+
+                if (currentRegion != null) {
+                    region = currentRegion.getName();
+                }
+            }
+            Region awsRegion = Region.getRegion(Regions.fromName(region));
             if (client != null) {
-                SimpleDBRecorder simpleDbRecorder = new SimpleDBRecorder(client, domain);
+                SimpleDBRecorder simpleDbRecorder = new SimpleDBRecorder(client, awsRegion, domain);
                 simpleDbRecorder.init();
                 setRecorder(simpleDbRecorder);
             }

--- a/src/main/java/com/netflix/simianarmy/basic/conformity/BasicConformityMonkeyContext.java
+++ b/src/main/java/com/netflix/simianarmy/basic/conformity/BasicConformityMonkeyContext.java
@@ -101,6 +101,10 @@ public class BasicConformityMonkeyContext extends BasicSimianArmyContext impleme
 
         LOGGER.info(String.format("Conformity Monkey is running in: %s", regions));
 
+        String sdbRegion = configuration().getStr("simianarmy.conformity.sdb.region");
+        if (sdbRegion == null) {
+            sdbRegion = awsClient().region();
+        }
         String sdbDomain = configuration().getStrOrElse("simianarmy.conformity.sdb.domain", "SIMIAN_ARMY");
 
         String dbDriver = configuration().getStr("simianarmy.recorder.db.driver");
@@ -109,8 +113,9 @@ public class BasicConformityMonkeyContext extends BasicSimianArmyContext impleme
         String dbUrl = configuration().getStr("simianarmy.recorder.db.url");
         String dbTable = configuration().getStr("simianarmy.conformity.resources.db.table");
         
-        if (dbDriver == null) {       
-        	clusterTracker = new SimpleDBConformityClusterTracker(awsClient(), sdbDomain);
+        if (dbDriver == null) {
+            Region awsRegion = Region.getRegion(Regions.fromName(sdbRegion));
+        	clusterTracker = new SimpleDBConformityClusterTracker(awsClient(), awsRegion, sdbDomain);
         } else {
         	RDSConformityClusterTracker rdsClusterTracker = new RDSConformityClusterTracker(dbDriver, dbUser, dbPass, dbUrl, dbTable);
         	rdsClusterTracker.init();

--- a/src/main/java/com/netflix/simianarmy/basic/janitor/BasicJanitorMonkeyContext.java
+++ b/src/main/java/com/netflix/simianarmy/basic/janitor/BasicJanitorMonkeyContext.java
@@ -95,6 +95,10 @@ public class BasicJanitorMonkeyContext extends BasicSimianArmyContext implements
         monkeyRegion = region();
         monkeyCalendar = calendar();
 
+        String resourceRegion = configuration().getStr("simianarmy.janitor.resources.sdb.region");
+        if (resourceRegion == null) {
+            resourceRegion = awsClient().region();
+        }
         String resourceDomain = configuration().getStrOrElse("simianarmy.janitor.resources.sdb.domain", "SIMIAN_ARMY");
 
         Set<String> enabledResourceSet = getEnabledResourceSet();
@@ -105,8 +109,9 @@ public class BasicJanitorMonkeyContext extends BasicSimianArmyContext implements
         String dbUrl = configuration().getStr("simianarmy.recorder.db.url");
         String dbTable = configuration().getStr("simianarmy.janitor.resources.db.table");
         
-        if (dbDriver == null) {       
-        	janitorResourceTracker = new SimpleDBJanitorResourceTracker(awsClient(), resourceDomain);
+        if (dbDriver == null) {
+            Region awsRegion = Region.getRegion(Regions.fromName(resourceRegion));
+        	janitorResourceTracker = new SimpleDBJanitorResourceTracker(awsClient(), awsRegion, resourceDomain);
         } else {
         	RDSJanitorResourceTracker rdsTracker = new RDSJanitorResourceTracker(dbDriver, dbUser, dbPass, dbUrl, dbTable);
         	rdsTracker.init();

--- a/src/main/resources/conformity.properties
+++ b/src/main/resources/conformity.properties
@@ -23,6 +23,7 @@ simianarmy.calendar.timezone = America/Los_Angeles
 simianarmy.conformity.notification.openHour = 0
 simianarmy.conformity.notification.closeHour = 24
 
+#simianarmy.conformity.sdb.region = us-east-1
 simianarmy.conformity.sdb.domain = SIMIAN_ARMY
 
 # The property below needs to be a valid email address to receive the summary email of Conformity Monkey

--- a/src/main/resources/janitor.properties
+++ b/src/main/resources/janitor.properties
@@ -16,6 +16,9 @@ simianarmy.janitor.enabled = true
 # Don't allow Janitor Monkey to change resources (dryrun mode)
 simianarmy.janitor.leashed = true
 
+# The SDB region for storing the resources managed by the Janitor Monkey.
+#simianarmy.janitor.resources.sdb.region = us-east-1
+
 # The SDB domain for storing the resources managed by the Janitor Monkey.
 simianarmy.janitor.resources.sdb.domain = SIMIAN_ARMY
 

--- a/src/main/resources/simianarmy.properties
+++ b/src/main/resources/simianarmy.properties
@@ -1,6 +1,7 @@
 # see documentation at:
 # https://github.com/Netflix/SimianArmy/wiki/Configuration
 
+#simianarmy.recorder.sdb.region = us-east-1
 simianarmy.recorder.sdb.domain = SIMIAN_ARMY
 
 # If using a non-SimbleDB recorder (LocalDB), these settings tweak defaults.

--- a/src/test/java/com/netflix/simianarmy/aws/janitor/TestSimpleDBJanitorResourceTracker.java
+++ b/src/test/java/com/netflix/simianarmy/aws/janitor/TestSimpleDBJanitorResourceTracker.java
@@ -45,6 +45,8 @@ import com.amazonaws.services.simpledb.model.PutAttributesRequest;
 import com.amazonaws.services.simpledb.model.ReplaceableAttribute;
 import com.amazonaws.services.simpledb.model.SelectRequest;
 import com.amazonaws.services.simpledb.model.SelectResult;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.regions.Region;
 import com.netflix.simianarmy.Resource;
 import com.netflix.simianarmy.aws.AWSResource;
 import com.netflix.simianarmy.aws.AWSResourceType;
@@ -56,11 +58,12 @@ public class TestSimpleDBJanitorResourceTracker extends SimpleDBJanitorResourceT
         AmazonSimpleDB sdbMock = mock(AmazonSimpleDB.class);
         AWSClient awsClient = mock(AWSClient.class);
         when(awsClient.sdbClient()).thenReturn(sdbMock);
+        when(awsClient.region()).thenReturn("us-east-1");
         return awsClient;
     }
 
     public TestSimpleDBJanitorResourceTracker() {
-        super(makeMockAWSClient(), "DOMAIN");
+        super(makeMockAWSClient(), Region.getRegion(Regions.fromName("us-east-1")), "DOMAIN");
         sdbMock = super.getSimpleDBClient();
     }
 


### PR DESCRIPTION
Not every AWS region supports SimpleDB, e.g. eu-central-1. The result is that `SimpleDBRecorder`, `SimpleDBConformityClusterTracker` and `SimpleDBJanitorResourceTracker` fail with HTTP errors while connecting to SimpleDB.

This PR adds support for an override configuration that can be enabled when using these regions.