### PR TITLE
Fix querying LocalDB: consider all event fields when matching events

### DIFF
--- a/src/main/java/com/netflix/simianarmy/basic/LocalDbRecorder.java
+++ b/src/main/java/com/netflix/simianarmy/basic/LocalDbRecorder.java
@@ -135,23 +135,51 @@ public class LocalDbRecorder implements MonkeyRecorder {
         init();
         List<Event> foundEvents = new ArrayList<Event>();
         for (Event evt : eventMap.tailMap(toKey(after)).values()) {
-            boolean matched = true;
-            for (Map.Entry<String, String> pair : query.entrySet()) {
-                if (pair.getKey().equals("id") && !evt.id().equals(pair.getValue())) {
-                    matched = false;
-                }
-                if (pair.getKey().equals("monkeyType") && !evt.monkeyType().toString().equals(pair.getValue())) {
-                    matched = false;
-                }
-                if (pair.getKey().equals("eventType") && !evt.eventType().toString().equals(pair.getValue())) {
-                    matched = false;
-                }
-            }
-            if (matched) {
+            if (doesEventMatch(evt, query)) {
                 foundEvents.add(evt);
             }
         }
         return foundEvents;
+    }
+
+    private boolean doesEventMatch(Event evt, Map<String, String> query) {
+        for (Map.Entry<String, String> pair : query.entrySet()) {
+            switch (pair.getKey()) {
+                case "id":
+                    if (!evt.id().equals(pair.getValue())) {
+                        return false;
+                    }
+                    break;
+                case "eventTime":
+                    if (!evt.eventTime().equals(new Date(Long.parseLong(pair.getValue())))) {
+                        return false;
+                    }
+                    break;
+                case "monkeyType":
+                    if (!evt.monkeyType().toString().equals(pair.getValue())) {
+                        return false;
+                    }
+                    break;
+                case "eventType":
+                    if (!evt.eventType().toString().equals(pair.getValue())) {
+                        return false;
+                    }
+                    break;
+                case "region":
+                    if (!evt.region().equals(pair.getValue())) {
+                        return false;
+                    }
+                    break;
+                default:
+                    if (!evt.fields().containsKey(pair.getKey())) {
+                        return false;
+                    }
+                    if (!evt.field(pair.getKey()).equals(pair.getValue())) {
+                        return false;
+                    }
+            }
+        }
+        return true;
     }
 
     /* (non-Javadoc)

--- a/src/test/java/com/netflix/simianarmy/basic/TestLocalDbRecorder.java
+++ b/src/test/java/com/netflix/simianarmy/basic/TestLocalDbRecorder.java
@@ -1,0 +1,148 @@
+package com.netflix.simianarmy.basic;
+
+import com.google.common.collect.ImmutableMap;
+import com.netflix.simianarmy.MonkeyRecorder;
+import com.netflix.simianarmy.chaos.ChaosMonkey;
+import org.testng.annotations.Test;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestLocalDbRecorder {
+
+    private LocalDbRecorder localDbRecorder = new LocalDbRecorder(new BasicConfiguration(new Properties()));
+
+    @Test
+    public void testId() {
+        MonkeyRecorder.Event evt = makeEvent();
+        localDbRecorder.recordEvent(evt);
+
+        Map<String, String> query = ImmutableMap.of("id", evt.id());
+        List<MonkeyRecorder.Event> evts = performQuery(query);
+
+        assertEquals(evts.size(), 1);
+    }
+
+    @Test
+    public void testIdNoMatch() {
+        MonkeyRecorder.Event evt = makeEvent();
+        localDbRecorder.recordEvent(evt);
+
+        Map<String, String> query = ImmutableMap.of("id", "wrong-id");
+        List<MonkeyRecorder.Event> evts = performQuery(query);
+
+        assertEquals(evts.size(), 0);
+    }
+
+    @Test
+    public void testEventTime() {
+        MonkeyRecorder.Event evt = makeEvent();
+        localDbRecorder.recordEvent(evt);
+
+        Map<String, String> query = ImmutableMap.of("eventTime", Long.toString(evt.eventTime().getTime()));
+        List<MonkeyRecorder.Event> evts = performQuery(query);
+
+        assertEquals(evts.size(), 1);
+    }
+
+    @Test
+    public void testEventTimeNoMatch() {
+        MonkeyRecorder.Event evt = makeEvent();
+        localDbRecorder.recordEvent(evt);
+
+        Map<String, String> query = ImmutableMap.of("eventTime", Long.toString(evt.eventTime().getTime()-1));
+        List<MonkeyRecorder.Event> evts = performQuery(query);
+
+        assertEquals(evts.size(), 0);
+    }
+
+    @Test
+    public void testRegionMatch() {
+        MonkeyRecorder.Event evt = makeEvent("region-1");
+        localDbRecorder.recordEvent(evt);
+
+        Map<String, String> query = ImmutableMap.of("region", "region-1");
+        List<MonkeyRecorder.Event> evts = performQuery(query);
+
+        assertEquals(evts.size(), 1);
+    }
+
+    @Test
+    public void testRegionNoMatch() {
+        MonkeyRecorder.Event evt = makeEvent();
+        localDbRecorder.recordEvent(evt);
+
+        Map<String, String> query = ImmutableMap.of("region", "some-other-region");
+        List<MonkeyRecorder.Event> evts = performQuery(query);
+
+        assertEquals(evts.size(), 0);
+    }
+
+    @Test
+    public void testCustomFieldMatch() {
+        MonkeyRecorder.Event evt = makeEvent();
+        evt.addField("groupName", "group-name-1");
+        localDbRecorder.recordEvent(evt);
+
+        Map<String, String> query = ImmutableMap.of("groupName", "group-name-1");
+        List<MonkeyRecorder.Event> evts = performQuery(query);
+
+        assertEquals(evts.size(), 1);
+    }
+
+    @Test
+    public void testCustomFieldNoMatch() {
+        MonkeyRecorder.Event evt = makeEvent();
+        evt.addField("groupName", "group-name-1");
+        localDbRecorder.recordEvent(evt);
+
+        Map<String, String> query = ImmutableMap.of("groupName", "some-other-group-name");
+        List<MonkeyRecorder.Event> evts = performQuery(query);
+
+        assertEquals(evts.size(), 0);
+    }
+
+    @Test
+    public void testCustomFieldNotPresent() {
+        MonkeyRecorder.Event evt = makeEvent();
+        localDbRecorder.recordEvent(evt);
+
+        Map<String, String> query = ImmutableMap.of("groupName", "group-name-2");
+        List<MonkeyRecorder.Event> evts = performQuery(query);
+
+        assertEquals(evts.size(), 0);
+    }
+
+    @Test
+    public void testMultipleEventsMatch() {
+        final int numberOfEvents = 10;
+        for (int i = 0; i < numberOfEvents; i++) {
+            MonkeyRecorder.Event evt = makeEvent();
+            evt.addField("groupName", "group-name-3");
+            localDbRecorder.recordEvent(evt);
+        }
+
+        Map<String, String> query = ImmutableMap.of("groupName", "group-name-3");
+        List<MonkeyRecorder.Event> evts = performQuery(query);
+
+        assertEquals(evts.size(), numberOfEvents);
+    }
+
+    private List<MonkeyRecorder.Event> performQuery(Map<String, String> query) {
+        return localDbRecorder.findEvents(ChaosMonkey.Type.CHAOS, ChaosMonkey.EventTypes.CHAOS_TERMINATION, query, new Date(0));
+    }
+
+    private MonkeyRecorder.Event makeEvent(String region) {
+        return localDbRecorder.newEvent(ChaosMonkey.Type.CHAOS, ChaosMonkey.EventTypes.CHAOS_TERMINATION, region,
+                                        UUID.randomUUID().toString());
+    }
+
+    private MonkeyRecorder.Event makeEvent() {
+        return makeEvent("some-region");
+    }
+}


### PR DESCRIPTION
When using LocalDBRecorder, we found that the config simianarmy.chaos.ASG.maxTerminationsPerDay was not being respected.  This is because the groupName field was not being compared for matches, so getPreviousTerminationCount in BasicChaosMonkey always returned 0 terminations for the ASG.