### PR TITLE
fix(janitor): edda returns a single object if list of imageIds has 1 item

### DIFF
--- a/src/main/java/com/netflix/simianarmy/aws/janitor/crawler/edda/EddaImageJanitorCrawler.java
+++ b/src/main/java/com/netflix/simianarmy/aws/janitor/crawler/edda/EddaImageJanitorCrawler.java
@@ -163,6 +163,9 @@ public class EddaImageJanitorCrawler implements JanitorCrawler {
         String url = eddaClient.getBaseUrl(region) + "/aws/images";
         if (imageIds != null && imageIds.length != 0) {
             url += "/" + StringUtils.join(imageIds, ',');
+            if (imageIds.length == 1) {
+                url +=","; // Edda will return a non-array if passing exactly one imageId which will fail the crawler
+            }
             LOGGER.info(String.format("Getting unreferenced AMIs in region %s for %d ids", region, imageIds.length));
         } else {
             LOGGER.info(String.format("Getting all unreferenced AMIs in region %s", region));


### PR DESCRIPTION
- append a trailing comma to force edda to return an array