### PR TITLE
fix(janitor): Partitioning image ids for edda

### DIFF
--- a/src/main/java/com/netflix/simianarmy/aws/janitor/crawler/edda/EddaImageJanitorCrawler.java
+++ b/src/main/java/com/netflix/simianarmy/aws/janitor/crawler/edda/EddaImageJanitorCrawler.java
@@ -18,6 +18,7 @@
 
 package com.netflix.simianarmy.aws.janitor.crawler.edda;
 
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -37,14 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.EnumSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -144,7 +138,11 @@ public class EddaImageJanitorCrawler implements JanitorCrawler {
         Collection<String> excludedImageIds = getExcludedImageIds();
         List<Resource> resources = Lists.newArrayList();
         for (String region : regions) {
-            resources.addAll(getAMIResourcesInRegion(region, excludedImageIds, imageIds));
+            try {
+                resources.addAll(getAMIResourcesInRegion(region, excludedImageIds, imageIds));
+            } catch (Exception e) {
+                LOGGER.error("AMI look up failed for {} in {}", imageIds, region, e);
+            }
         }
         return resources;
     }
@@ -245,8 +243,43 @@ public class EddaImageJanitorCrawler implements JanitorCrawler {
         LOGGER.info(String.format("Got creation time for %d images", imageIdToCreationTime.size()));
     }
 
-    private List<Resource> getAMIResourcesInRegion(
-            String region, Collection<String> excludedImageIds, String... imageIds) {
+    private List<Resource> getAMIResourcesInRegion(String region,
+                                                   Collection<String> excludedImageIds,
+                                                   String... imageIds) {
+        LOGGER.info("Searching images with id(s) {} in {}", imageIds, region);
+        if (imageIds == null || imageIds.length == 0) {
+            return doGetAmisByRegion(
+                region,
+                excludedImageIds,
+                imageIds
+            );
+        }
+
+        List<String> ids = Arrays.asList(imageIds);
+        List<Resource> result = new ArrayList<>();
+        // partitions of 25 to avoid exceeding URI max length on edda endpoints
+        for (List<String> partition : Lists.partition(ids, 25)) {
+            try {
+                List<Resource> resources = doGetAmisByRegion(
+                    region,
+                    excludedImageIds,
+                    Iterables.toArray(
+                        partition,
+                        String.class
+                    )
+                );
+
+                LOGGER.info("Fetched {} images with ids {}", resources.size(), partition);
+                result.addAll(resources);
+            } catch (Exception e) {
+                LOGGER.error("Failure while looking up image ids {} in {}", partition, region, e);
+            }
+        }
+
+        return result;
+    }
+
+    private List<Resource> doGetAmisByRegion(String region, Collection<String> excludedImageIds, String... imageIds) {
         JsonNode jsonNode = getImagesInJson(region, imageIds);
         List<Resource> resources = Lists.newArrayList();
         for (Iterator<JsonNode> it = jsonNode.getElements(); it.hasNext();) {
@@ -284,6 +317,7 @@ public class EddaImageJanitorCrawler implements JanitorCrawler {
 
         return resources;
     }
+
 
     private Resource parseJsonElementToresource(String region, JsonNode jsonNode) {
         Validate.notNull(jsonNode);


### PR DESCRIPTION
- should handle the URI too long due to a large number of ami ids