### PR TITLE
Include the AWS session token when using temporary credentials

### DIFF
--- a/src/main/java/com/netflix/simianarmy/client/aws/AWSClient.java
+++ b/src/main/java/com/netflix/simianarmy/client/aws/AWSClient.java
@@ -19,7 +19,9 @@ package com.netflix.simianarmy.client.aws;
 
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSSessionCredentials;
 import com.amazonaws.services.autoscaling.AmazonAutoScalingClient;
 import com.amazonaws.services.autoscaling.model.*;
 import com.amazonaws.services.ec2.AmazonEC2;
@@ -40,20 +42,24 @@ import com.amazonaws.services.simpledb.AmazonSimpleDB;
 import com.amazonaws.services.simpledb.AmazonSimpleDBClient;
 import com.google.common.base.Objects;
 import com.google.common.base.Strings;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.google.inject.Module;
 import com.netflix.simianarmy.CloudClient;
 import com.netflix.simianarmy.NotFoundException;
+
 import org.apache.commons.lang.Validate;
 import org.jclouds.ContextBuilder;
+import org.jclouds.aws.domain.SessionCredentials;
 import org.jclouds.compute.ComputeService;
 import org.jclouds.compute.ComputeServiceContext;
 import org.jclouds.compute.Utils;
 import org.jclouds.compute.domain.ComputeMetadata;
 import org.jclouds.compute.domain.NodeMetadata;
 import org.jclouds.compute.domain.NodeMetadataBuilder;
+import org.jclouds.domain.Credentials;
 import org.jclouds.domain.LoginCredentials;
 import org.jclouds.logging.slf4j.config.SLF4JLoggingModule;
 import org.jclouds.ssh.SshClient;
@@ -860,11 +866,23 @@ public class AWSClient implements CloudClient {
         if (jcloudsComputeService == null) {
             synchronized(this) {
                 if (jcloudsComputeService == null) {
-                    String username = awsCredentialsProvider.getCredentials().getAWSAccessKeyId();
-                    String password = awsCredentialsProvider.getCredentials().getAWSSecretKey();
-                    ComputeServiceContext jcloudsContext = ContextBuilder.newBuilder("aws-ec2").credentials(username, password)
-                            .modules(ImmutableSet.<Module>of(new SLF4JLoggingModule(), new JschSshClientModule()))
-                            .buildView(ComputeServiceContext.class);
+		    AWSCredentials awsCredentials = awsCredentialsProvider.getCredentials();
+		    String username = awsCredentials.getAWSAccessKeyId();
+		    String password = awsCredentials.getAWSSecretKey();
+
+		    Credentials credentials;
+		    if (awsCredentials instanceof AWSSessionCredentials) {
+			AWSSessionCredentials awsSessionCredentials = (AWSSessionCredentials) awsCredentials;
+			credentials = SessionCredentials.builder().accessKeyId(username).secretAccessKey(password)
+				.sessionToken(awsSessionCredentials.getSessionToken()).build();
+		    } else {
+			credentials = new Credentials(username, password);
+		    }
+
+		    ComputeServiceContext jcloudsContext = ContextBuilder.newBuilder("aws-ec2")
+			    .credentialsSupplier(Suppliers.ofInstance(credentials))
+			    .modules(ImmutableSet.<Module>of(new SLF4JLoggingModule(), new JschSshClientModule()))
+			    .buildView(ComputeServiceContext.class);
 
                     this.jcloudsComputeService = jcloudsContext.getComputeService();
                 }


### PR DESCRIPTION
When using temporary credentials, the session token [must be included](https://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html#UsingTemporarySecurityCredentials) in the request. This PR checks which is the type of the credentials object being used and configures the AWSClient accordingly.