### PR TITLE
Solution to network related scripts not running successfully

### DIFF
--- a/src/main/resources/scripts/networkcorruption.sh
+++ b/src/main/resources/scripts/networkcorruption.sh
@@ -2,4 +2,4 @@
 # Script for NetworkCorruption Chaos Monkey
 
 # Corrupts 5% of packets
-tc qdisc add dev eth0 root netem corrupt 5%
+sudo tc qdisc add dev eth0 root netem corrupt 5%

--- a/src/main/resources/scripts/networklatency.sh
+++ b/src/main/resources/scripts/networklatency.sh
@@ -2,5 +2,5 @@
 # Script for NetworkLatency Chaos Monkey
 
 # Adds 1000ms +- 500ms of latency to each packet
-tc qdisc add dev eth0 root latency delay 1000ms 500ms
+sudo tc qdisc add dev eth0 root netem delay 1000ms 500ms
 

--- a/src/main/resources/scripts/networkloss.sh
+++ b/src/main/resources/scripts/networkloss.sh
@@ -3,6 +3,6 @@
 
 # Drops 7% of packets, with 25% correlation with previous packet loss
 # 7% is high, but it isn't high enough that TCP will fail entirely
-tc qdisc add dev eth0 root netem loss 7% 25%
+sudo tc qdisc add dev eth0 root netem loss 7% 25%
 
 


### PR DESCRIPTION
Added sudo to front of the scripts to provide root access.
qdisc module "latency" not recognised error, so changed it to "netem" and works fine.

reference to issue #296 

